### PR TITLE
feat: add default MUI dark theme

### DIFF
--- a/src/theme/provider/ThemeProvider.tsx
+++ b/src/theme/provider/ThemeProvider.tsx
@@ -1,4 +1,5 @@
 import { StyledEngineProvider, ThemeProvider as BaseThemeProvider } from "@mui/material/styles";
+import { Theme } from "@mui/material/styles/createTheme";
 import React from "react";
 
 import { AlertContextProvider } from "../../mui/components/custom/alert/AlertContextProvider";
@@ -10,12 +11,16 @@ import LightMaterialUITheme from "../theme";
  * */
 export interface ThemeProviderProps {
     children: React.ReactNode;
+    theme?: Theme;
 }
 
-export default function ThemeProvider({ children }: ThemeProviderProps) {
+export default function ThemeProvider({
+    children,
+    theme = LightMaterialUITheme,
+}: ThemeProviderProps) {
     return (
         <StyledEngineProvider injectFirst>
-            <BaseThemeProvider theme={LightMaterialUITheme}>
+            <BaseThemeProvider theme={theme}>
                 <AlertContextProvider>{children}</AlertContextProvider>
             </BaseThemeProvider>
         </StyledEngineProvider>

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,7 +1,7 @@
-import { createTheme } from "@mui/material/styles";
+import { createTheme, Theme } from "@mui/material/styles";
 
 import buttons from "./components/buttons";
-import palette from "./palette";
+import lightPalette from "./palette";
 import shadows from "./shadows";
 import typography from "./typography";
 
@@ -11,9 +11,7 @@ export const sizesConfig = {
     },
 };
 
-export const theme = createTheme({ palette });
-
-const LightMaterialUITheme = createTheme(theme, {
+const commonSettings = {
     dropdownPopperZindex: 2147483647,
     iconDefaultFontSize: 20,
     fonts: {
@@ -43,6 +41,12 @@ const LightMaterialUITheme = createTheme(theme, {
                 height: sizesConfig.buttonPrimary.height,
             },
         },
+        toolbar: {
+            xl: {
+                width: "64px",
+                height: "64px",
+            },
+        },
         header: {
             subHeader: {
                 height: "30px",
@@ -58,33 +62,49 @@ const LightMaterialUITheme = createTheme(theme, {
             xl: 1536,
         },
     },
-    typography: typography(theme),
-    shadows: shadows(theme),
-    components: {
-        ...buttons(theme),
-        /**
-         * Styles below adjust MUI TablePagination component to the current wep-app style
-         * Should be removed after moving explorer to the MUI Data Grid
-         */
-        MuiTablePagination: {
-            styleOverrides: {
-                toolbar: {
-                    "@media (min-width: 0px)": {
-                        minHeight: "30px",
-                        paddingLeft: 0,
-                    },
-                    fontSize: "12px",
+};
+
+/**
+ * Styles below adjust MUI TablePagination component to the current wep-app style
+ * Should be removed after moving explorer to the MUI Data Grid
+ */
+const MUITablePaginationSettings = {
+    MuiTablePagination: {
+        styleOverrides: {
+            toolbar: {
+                "@media (min-width: 0px)": {
+                    minHeight: "30px",
+                    paddingLeft: 0,
                 },
-                displayedRows: {
-                    margin: 0,
-                    fontSize: "12px",
-                },
-                actions: {
-                    marginLeft: 0,
-                },
+                fontSize: "12px",
+            },
+            displayedRows: {
+                margin: 0,
+                fontSize: "12px",
+            },
+            actions: {
+                marginLeft: 0,
             },
         },
     },
-});
+};
+
+export const theme = createTheme({ palette: lightPalette });
+// default MUI dark theme:
+export const darkTheme = createTheme({ palette: { mode: "dark" } });
+const themeGenerator = (theme: Theme) => {
+    return createTheme(theme, {
+        ...commonSettings,
+        typography: typography(theme),
+        shadows: shadows(theme),
+        components: {
+            ...buttons(theme),
+            ...MUITablePaginationSettings,
+        },
+    });
+};
+
+const LightMaterialUITheme = themeGenerator(theme);
+export const DarkMaterialUITheme = themeGenerator(darkTheme);
 
 export default LightMaterialUITheme;

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -92,7 +92,7 @@ const MUITablePaginationSettings = {
 export const theme = createTheme({ palette: lightPalette });
 // default MUI dark theme:
 export const darkTheme = createTheme({ palette: { mode: "dark" } });
-const themeGenerator = (theme: Theme) => {
+const buildTheme = (theme: Theme) => {
     return createTheme(theme, {
         ...commonSettings,
         typography: typography(theme),
@@ -104,7 +104,7 @@ const themeGenerator = (theme: Theme) => {
     });
 };
 
-const LightMaterialUITheme = themeGenerator(theme);
-export const DarkMaterialUITheme = themeGenerator(darkTheme);
+const LightMaterialUITheme = buildTheme(theme);
+export const DarkMaterialUITheme = buildTheme(darkTheme);
 
 export default LightMaterialUITheme;

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -41,12 +41,6 @@ const commonSettings = {
                 height: sizesConfig.buttonPrimary.height,
             },
         },
-        toolbar: {
-            xl: {
-                width: "64px",
-                height: "64px",
-            },
-        },
         header: {
             subHeader: {
                 height: "30px",
@@ -99,6 +93,7 @@ const buildTheme = (theme: Theme) => {
         shadows: shadows(theme),
         components: {
             ...buttons(theme),
+            // TODO: REMOVE! this styles after moving explorer to the MUI Data Grid
             ...MUITablePaginationSettings,
         },
     });


### PR DESCRIPTION
First step in the effort to create two equally usable themes. 

LightMaterialUITheme is default export as previously, no change will be needed for existing usages, DarkMaterialUITheme is a named export -- for those who know about it.

** Breaking changes might still occur ** -- do tests in cove.js cover everything?