### PR TITLE
chore: update codemirror 5.47.0 to 6.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1846,9 +1846,18 @@
             "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
         },
         "codemirror": {
-            "version": "5.65.13",
-            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.13.tgz",
-            "integrity": "sha512-SVWEzKXmbHmTQQWaz03Shrh4nybG0wXx2MEu3FO4ezbPW8IbnZEd5iGHGEffSUaitKYa3i+pHpBsSvw8sPHtzg=="
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
+            "integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
+            "requires": {
+                "@codemirror/autocomplete": "^6.0.0",
+                "@codemirror/commands": "^6.0.0",
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/lint": "^6.0.0",
+                "@codemirror/search": "^6.0.0",
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.0.0"
+            }
         },
         "color-convert": {
             "version": "1.9.3",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "@types/react-beautiful-dnd": "^13.1.4",
         "@types/underscore.string": "0.0.38",
         "@uiw/react-codemirror": "^4.19.9",
-        "codemirror": "^5.47.0",
+        "codemirror": "6.0.1",
         "jszip": "^3.0.0",
         "jszip-utils": "0.0.2",
         "katex": "^0.16.7",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "@types/react-beautiful-dnd": "^13.1.4",
         "@types/underscore.string": "0.0.38",
         "@uiw/react-codemirror": "^4.19.9",
-        "codemirror": "6.0.1",
+        "codemirror": "^6.0.1",
         "jszip": "^3.0.0",
         "jszip-utils": "0.0.2",
         "katex": "^0.16.7",

--- a/src/other/codemirror/CodeMirror.tsx
+++ b/src/other/codemirror/CodeMirror.tsx
@@ -1,9 +1,9 @@
-import "codemirror/lib/codemirror.css";
-import "codemirror/mode/jinja2/jinja2";
-import "codemirror/mode/fortran/fortran";
-import "codemirror/mode/shell/shell";
-import "codemirror/mode/python/python";
-import "codemirror/mode/javascript/javascript";
+// import "codemirror/lib/codemirror.css";
+// import "codemirror/mode/jinja2/jinja2";
+// import "codemirror/mode/fortran/fortran";
+// import "codemirror/mode/shell/shell";
+// import "codemirror/mode/python/python";
+// import "codemirror/mode/javascript/javascript";
 
 import { autocompletion, CompletionContext, CompletionResult } from "@codemirror/autocomplete";
 import { javascript } from "@codemirror/lang-javascript";

--- a/src/other/codemirror/CodeMirror.tsx
+++ b/src/other/codemirror/CodeMirror.tsx
@@ -1,10 +1,3 @@
-// import "codemirror/lib/codemirror.css";
-// import "codemirror/mode/jinja2/jinja2";
-// import "codemirror/mode/fortran/fortran";
-// import "codemirror/mode/shell/shell";
-// import "codemirror/mode/python/python";
-// import "codemirror/mode/javascript/javascript";
-
 import { autocompletion, CompletionContext, CompletionResult } from "@codemirror/autocomplete";
 import { javascript } from "@codemirror/lang-javascript";
 import { json, jsonParseLinter } from "@codemirror/lang-json";


### PR DESCRIPTION
Threejs editor in the latest wave.js uses codemirror 6+, otherwise it fails. 
