### PR TITLE
feat/SOF-6471

### DIFF
--- a/src/mui/components/icon/IconByName.tsx
+++ b/src/mui/components/icon/IconByName.tsx
@@ -327,7 +327,7 @@ const iconComponentMap: Record<string, typeof SvgIcon | ReturnType<typeof rotate
     "actions.visualize": OpenInBrowser,
 
     "shapes.arrow.doubleUp": DoubleArrow,
-    "shapes.arrow.down": rotateIcon(KeyboardArrowUp, 180),
+    "shapes.arrow.down": KeyboardArrowDown,
     "shapes.arrow.dropdown": ArrowDropDown,
     "shapes.arrow.fold": UnfoldLess,
     "shapes.arrow.swap": SwapVert,


### PR DESCRIPTION
This PR removes the use of rotateIcon for arrows, due to lack of update propagation in web-app