### PR TITLE
updated DNS icon to filled one

### DIFF
--- a/src/mui/components/icon/IconByName.tsx
+++ b/src/mui/components/icon/IconByName.tsx
@@ -39,7 +39,7 @@ import Delete from "@mui/icons-material/Delete";
 import Description from "@mui/icons-material/Description";
 import DesktopWindowsOutlined from "@mui/icons-material/DesktopWindowsOutlined";
 import DirectionsWalk from "@mui/icons-material/DirectionsWalk";
-import DnsOutlined from "@mui/icons-material/DnsOutlined";
+import Dns from '@mui/icons-material/Dns';
 import DoubleArrow from "@mui/icons-material/DoubleArrow";
 import Download from "@mui/icons-material/Download";
 import DragIndicator from "@mui/icons-material/DragIndicator";
@@ -231,7 +231,7 @@ const iconComponentMap: Record<string, typeof SvgIcon | ReturnType<typeof rotate
     "pages.bio.link": Link,
     "pages.bio.location": LocationOn,
     "pages.compute": Settings,
-    "pages.computeLoad": DnsOutlined,
+    "pages.computeLoad": Dns,
     "pages.createJob": PlaylistAdd,
     "pages.dashboard": Dashboard,
     "pages.documentation": SupportOutlined,


### PR DESCRIPTION
Old icon
<img width="127" alt="image" src="https://github.com/Exabyte-io/cove.js/assets/5090118/58d5b8f8-3d6d-4de4-b086-dc8fd6642251">


New icon
<img width="1021" alt="Screenshot 2023-10-16 at 10 12 03 AM" src="https://github.com/Exabyte-io/cove.js/assets/5090118/343be6a6-a06a-49a3-a0ac-6de2a230e786">

