### PR TITLE
fix/buttonStyle

### DIFF
--- a/src/mui/components/button/ButtonMultiSelect.tsx
+++ b/src/mui/components/button/ButtonMultiSelect.tsx
@@ -20,7 +20,8 @@
  *    ]}
  *    localStorageKey="myButtonSelectKey"
  *    size="medium"
- *    compact={true}
+ *    isLoading={false}
+ *    isCompact={true}
  * />
  * ```
  */

--- a/src/mui/components/button/ButtonMultiSelect.tsx
+++ b/src/mui/components/button/ButtonMultiSelect.tsx
@@ -9,7 +9,6 @@
  * Usage:
  * To use this component, define an array of ButtonConfig objects, each representing a button's configuration.
  * Pass this array along with a localStorage key (for saving the selected button's state) to the component.
- * Optionally, you can also specify the size of the buttons (see https://mui.com/material-ui/react-button/#sizes).
  *
  * Example:
  * ```

--- a/src/mui/components/button/ButtonMultiSelect.tsx
+++ b/src/mui/components/button/ButtonMultiSelect.tsx
@@ -20,6 +20,7 @@
  *    ]}
  *    localStorageKey="myButtonSelectKey"
  *    size="medium"
+ *    compact={true}
  * />
  * ```
  */
@@ -46,6 +47,7 @@ type ButtonMultiSelectProps = {
     size?: "small" | "medium" | "large";
     localStorageKey: string;
     isLoading?: boolean;
+    isCompact?: boolean;
 };
 
 function ButtonMultiSelect({
@@ -54,6 +56,7 @@ function ButtonMultiSelect({
     size = "small",
     localStorageKey,
     isLoading = false,
+    isCompact = false,
 }: ButtonMultiSelectProps) {
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
     const [selectedOption, setSelectedOption] = useState<ButtonConfig>(buttonConfigs[0]);
@@ -87,11 +90,7 @@ function ButtonMultiSelect({
 
     return (
         <>
-            <ButtonGroup
-                variant="contained"
-                size={size}
-                aria-label="outlined primary button group"
-                sx={{ height: "fit-content" }}>
+            <ButtonGroup variant="contained" size={size} sx={{ height: "fit-content" }}>
                 <LoadingButton
                     id={id}
                     ref={mainButtonRef}
@@ -99,8 +98,14 @@ function ButtonMultiSelect({
                     onClick={selectedOption.onClick}
                     variant="contained"
                     loading={isLoading}
-                    startIcon={<IconByName name={selectedOption.iconName} fontSize={size} />}>
-                    {selectedOption.label}
+                    startIcon={
+                        !isCompact && <IconByName name={selectedOption.iconName} fontSize={size} />
+                    }>
+                    {isCompact ? (
+                        <IconByName name={selectedOption.iconName} fontSize={size} />
+                    ) : (
+                        selectedOption.label
+                    )}
                 </LoadingButton>
                 <Button onClick={handleExpandClick} size={size}>
                     <IconByName name="shapes.arrow.dropdown" fontSize={size} />

--- a/src/theme/components/buttons.ts
+++ b/src/theme/components/buttons.ts
@@ -2,6 +2,9 @@ import { Theme } from "@mui/material/styles";
 
 const buttons = (theme: Theme) => {
     const config = {
+        root: {
+            whiteSpace: "nowrap",
+        },
         variants: [
             {
                 props: { size: "large" },
@@ -28,6 +31,7 @@ const buttons = (theme: Theme) => {
                     color: theme.palette.primary.main,
                     boxShadow: theme.shadows[2],
                     padding: "8px 22px",
+                    whiteSpace: "nowrap", // Add this line
 
                     "&:hover": {
                         backgroundColor: "rgba(16,86,190,0.2)",

--- a/src/theme/components/buttons.ts
+++ b/src/theme/components/buttons.ts
@@ -2,8 +2,10 @@ import { Theme } from "@mui/material/styles";
 
 const buttons = (theme: Theme) => {
     const config = {
-        root: {
-            whiteSpace: "nowrap",
+        styleOverrides: {
+            root: {
+                whiteSpace: "nowrap",
+            },
         },
         variants: [
             {
@@ -31,8 +33,6 @@ const buttons = (theme: Theme) => {
                     color: theme.palette.primary.main,
                     boxShadow: theme.shadows[2],
                     padding: "8px 22px",
-                    whiteSpace: "nowrap", // Add this line
-
                     "&:hover": {
                         backgroundColor: "rgba(16,86,190,0.2)",
                     },

--- a/src/theme/components/buttons.ts
+++ b/src/theme/components/buttons.ts
@@ -4,6 +4,7 @@ const buttons = (theme: Theme) => {
     const config = {
         styleOverrides: {
             root: {
+                // b/c of https://github.com/material-components/material-components-web/issues/4894
                 whiteSpace: "nowrap",
             },
         },


### PR DESCRIPTION
This PR includes two changes:
1. Default styling for button added: `whitespace: "nowrap"`. See here for more info on why this is necessary, and should be the desired behavior: [MUI issue](https://github.com/material-components/material-components-web/issues/4894)
2. Compact mode prop added to ButtonMultiSelectComponent to remove text label and show only the icon for smaller screen sizes