### PR TITLE
fix/muiStyling

### DIFF
--- a/src/mui/components/select/Select.tsx
+++ b/src/mui/components/select/Select.tsx
@@ -76,7 +76,6 @@ export default function SelectComponent({
                 multiple={multiple}
                 sx={{
                     width: "100%",
-                    minHeight: 56,
                     fontSize,
                     ...sx,
                 }}

--- a/src/theme/components/buttons.ts
+++ b/src/theme/components/buttons.ts
@@ -59,12 +59,18 @@ const buttons = (
                     // fixed heights for all sizes
                     "&.MuiButton-sizeSmall": {
                         height: commonSettings.sizes.button.height.small,
+                        paddingLeft: "10px",
+                        paddingRight: "10px",
                     },
                     "&.MuiButton-sizeMedium": {
                         height: commonSettings.sizes.button.height.medium,
+                        paddingLeft: "16px",
+                        paddingRight: "16px",
                     },
                     "&.MuiButton-sizeLarge": {
                         height: commonSettings.sizes.button.height.large,
+                        paddingLeft: "22px",
+                        paddingRight: "22px",
                     },
                     // change icon size to prevent icon from increasing button size
                     "&.MuiButton-root .MuiSvgIcon-root": {

--- a/src/theme/components/buttons.ts
+++ b/src/theme/components/buttons.ts
@@ -28,6 +28,9 @@ const buttons = (
                     "&.MuiIconButton-sizeLarge": {
                         padding: `calc(${theme.spacing(2)} - 5px)`,
                     },
+                    "&.MuiIconButton-root .MuiSvgIcon-root": {
+                        fontSize: "24px",
+                    },
                 },
             },
         },

--- a/src/theme/components/buttons.ts
+++ b/src/theme/components/buttons.ts
@@ -6,7 +6,7 @@ const defaultRootStyles = {
 };
 
 type SizeConfig = {
-    height: string;
+    height: number;
     icon: string;
     startIcon: string;
     paddingX?: number;
@@ -18,7 +18,7 @@ const getButtonSizeStyles = (
     { includePadding = true, fixedHeight = true },
 ) => {
     return {
-        ...(fixedHeight && config.height && { height: config.height }),
+        ...(fixedHeight && config.height && { height: theme.spacing(config.height) }),
         ...(includePadding &&
             config.paddingX && {
                 paddingLeft: theme.spacing(config.paddingX),

--- a/src/theme/components/buttons.ts
+++ b/src/theme/components/buttons.ts
@@ -1,32 +1,37 @@
 import { Theme } from "@mui/material/styles";
 
+const defaultRootStyles = {
+    minWidth: "fit-content",
+    height: "fit-content",
+};
+
 type SizeConfig = {
     height: string;
     icon: string;
     startIcon: string;
-    paddingX?: string;
+    paddingX?: number;
 };
 
-const getButtonSizeStyles = (config: SizeConfig, { includePadding = true, fixedHeight = true }) => {
+const getButtonSizeStyles = (
+    theme: Theme,
+    config: SizeConfig,
+    { includePadding = true, fixedHeight = true },
+) => {
     return {
         ...(fixedHeight && config.height && { height: config.height }),
         ...(includePadding &&
             config.paddingX && {
-                paddingLeft: config.paddingX,
-                paddingRight: config.paddingX,
+                paddingLeft: theme.spacing(config.paddingX),
+                paddingRight: theme.spacing(config.paddingX),
             }),
         "& .MuiSvgIcon-root": {
             fontSize: config.icon,
         },
+        // start and end icons should be closer to the text font size
         "& .MuiButton-startIcon .MuiSvgIcon-root, & .MuiButton-endIcon .MuiSvgIcon-root": {
             fontSize: config.startIcon,
         },
     };
-};
-
-const defaultRootStyles = {
-    minWidth: "fit-content",
-    height: "fit-content",
 };
 
 const buttons = (
@@ -49,13 +54,19 @@ const buttons = (
                     ...defaultRootStyles,
                 },
                 sizeSmall: {
-                    ...getButtonSizeStyles(buttonSizeConfig.small, { includePadding: false }),
+                    ...getButtonSizeStyles(theme, buttonSizeConfig.small, {
+                        includePadding: false,
+                    }),
                 },
                 sizeMedium: {
-                    ...getButtonSizeStyles(buttonSizeConfig.medium, { includePadding: false }),
+                    ...getButtonSizeStyles(theme, buttonSizeConfig.medium, {
+                        includePadding: false,
+                    }),
                 },
                 sizeLarge: {
-                    ...getButtonSizeStyles(buttonSizeConfig.large, { includePadding: false }),
+                    ...getButtonSizeStyles(theme, buttonSizeConfig.large, {
+                        includePadding: false,
+                    }),
                 },
             },
         },
@@ -67,13 +78,15 @@ const buttons = (
                     whiteSpace: "nowrap",
                 },
                 sizeSmall: {
-                    ...getButtonSizeStyles(buttonSizeConfig.small, { includePadding: true }),
+                    ...getButtonSizeStyles(theme, buttonSizeConfig.small, { includePadding: true }),
                 },
                 sizeMedium: {
-                    ...getButtonSizeStyles(buttonSizeConfig.medium, { includePadding: true }),
+                    ...getButtonSizeStyles(theme, buttonSizeConfig.medium, {
+                        includePadding: true,
+                    }),
                 },
                 sizeLarge: {
-                    ...getButtonSizeStyles(buttonSizeConfig.large, { includePadding: true }),
+                    ...getButtonSizeStyles(theme, buttonSizeConfig.large, { includePadding: true }),
                 },
             },
         },
@@ -83,19 +96,19 @@ const buttons = (
                     ...defaultRootStyles,
                 },
                 sizeSmall: {
-                    ...getButtonSizeStyles(buttonSizeConfig.small, {
+                    ...getButtonSizeStyles(theme, buttonSizeConfig.small, {
                         includePadding: false,
                         fixedHeight: false,
                     }),
                 },
                 sizeMedium: {
-                    ...getButtonSizeStyles(buttonSizeConfig.medium, {
+                    ...getButtonSizeStyles(theme, buttonSizeConfig.medium, {
                         includePadding: false,
                         fixedHeight: false,
                     }),
                 },
                 sizeLarge: {
-                    ...getButtonSizeStyles(buttonSizeConfig.large, {
+                    ...getButtonSizeStyles(theme, buttonSizeConfig.large, {
                         includePadding: false,
                         fixedHeight: false,
                     }),

--- a/src/theme/components/buttons.ts
+++ b/src/theme/components/buttons.ts
@@ -1,41 +1,122 @@
 import { Theme } from "@mui/material/styles";
 
-const buttons = (theme: Theme) => {
-    const config = {
-        styleOverrides: {
-            root: {
-                // b/c of https://github.com/material-components/material-components-web/issues/4894
-                whiteSpace: "nowrap",
+const buttons = (
+    theme: Theme,
+    commonSettings: {
+        sizes: {
+            input: {
+                defaultLineHeight: string;
+                largeLineHeight: string;
+            };
+        };
+    },
+) => {
+    const { defaultLineHeight, largeLineHeight } = commonSettings.sizes.input;
+
+    return {
+        MuiIconButton: {
+            styleOverrides: {
+                root: {
+                    minWidth: "fit-content",
+                    height: "fit-content",
+                    "&.MuiIconButton-sizeSmall": {
+                        padding: `calc(${theme.spacing(1)} - .5px)`,
+                    },
+                    "&.MuiIconButton-sizeMedium": {
+                        padding: `calc(${theme.spacing(1.5)} - .5px)`,
+                    },
+                    "&.MuiIconButton-sizeLarge": {
+                        padding: `calc(${theme.spacing(2)} - 5px)`,
+                    },
+                },
             },
         },
-        variants: [
-            {
-                props: { size: "large" },
-                style: {
-                    fontSize: "15px",
+        MuiButton: {
+            styleOverrides: {
+                root: {
+                    minWidth: "fit-content",
+                    height: "fit-content",
+                    // b/c of https://github.com/material-components/material-components-web/issues/4894
+                    whiteSpace: "nowrap",
+                    "&.MuiButton-sizeSmall": {
+                        lineHeight: defaultLineHeight,
+                        paddingTop: theme.spacing(1),
+                        paddingBottom: theme.spacing(1),
+                        paddingLeft: theme.spacing(1.5),
+                        paddingRight: theme.spacing(1.5),
+                    },
+                    "&.MuiButton-contained.MuiButton-sizeSmall": {
+                        paddingTop: `calc(${theme.spacing(1)} + 1px)`,
+                        paddingBottom: `calc(${theme.spacing(1)} + 1px)`,
+                        paddingLeft: `calc(${theme.spacing(1.5)} + 1px)`,
+                        paddingRight: `calc(${theme.spacing(1.5)} + 1px)`,
+                    },
+                    "&.MuiButton-text.MuiButton-sizeSmall": {
+                        paddingTop: `calc(${theme.spacing(1)} + 1px)`,
+                        paddingBottom: `calc(${theme.spacing(1)} + 1px)`,
+                        paddingLeft: `calc(${theme.spacing(1.5)} + 1px)`,
+                        paddingRight: `calc(${theme.spacing(1.5)} + 1px)`,
+                    },
+                    "&.MuiButton-sizeMedium": {
+                        lineHeight: defaultLineHeight,
+                        paddingTop: theme.spacing(1.5),
+                        paddingBottom: theme.spacing(1.5),
+                        paddingLeft: theme.spacing(2),
+                        paddingRight: theme.spacing(2),
+                    },
+                    "&.MuiButton-contained.MuiButton-sizeMedium": {
+                        paddingTop: `calc(${theme.spacing(1.5)} + 1px)`,
+                        paddingBottom: `calc(${theme.spacing(1.5)} + 1px)`,
+                        paddingLeft: `calc(${theme.spacing(2)} + 1px)`,
+                        paddingRight: `calc(${theme.spacing(2)} + 1px)`,
+                    },
+                    "&.MuiButton-text.MuiButton-sizeMedium": {
+                        paddingTop: `calc(${theme.spacing(1.5)} + 1px)`,
+                        paddingBottom: `calc(${theme.spacing(1.5)} + 1px)`,
+                        paddingLeft: `calc(${theme.spacing(2)} + 1px)`,
+                        paddingRight: `calc(${theme.spacing(2)} + 1px)`,
+                    },
+                    "&.MuiButton-sizeLarge": {
+                        lineHeight: largeLineHeight,
+                        paddingTop: theme.spacing(2),
+                        paddingBottom: theme.spacing(2),
+                        paddingLeft: theme.spacing(2.5),
+                        paddingRight: theme.spacing(2.5),
+                    },
+                    "&.MuiButton-contained.MuiButton-sizeLarge": {
+                        paddingTop: `calc(${theme.spacing(2)} + 1px)`,
+                        paddingBottom: `calc(${theme.spacing(2)} + 1px)`,
+                        paddingLeft: `calc(${theme.spacing(2.5)} + 1px)`,
+                        paddingRight: `calc(${theme.spacing(2.5)} + 1px)`,
+                    },
+                    "&.MuiButton-text.MuiButton-sizeLarge": {
+                        paddingTop: `calc(${theme.spacing(2)} + 1px)`,
+                        paddingBottom: `calc(${theme.spacing(2)} + 1px)`,
+                        paddingLeft: `calc(${theme.spacing(2.5)} + 1px)`,
+                        paddingRight: `calc(${theme.spacing(2.5)} + 1px)`,
+                    },
+                    // small and medium icons
+                    "&.MuiButton-root .MuiSvgIcon-root": {
+                        fontSize: defaultLineHeight,
+                        lineHeight: defaultLineHeight,
+                    },
+                    // large icons
+                    "&.MuiButton-sizeLarge .MuiSvgIcon-root": {
+                        fontSize: largeLineHeight,
+                        lineHeight: largeLineHeight,
+                    },
                 },
             },
-            {
-                props: { size: "medium" },
-                style: {
-                    fontSize: "14px",
-                },
-            },
-            {
-                props: { size: "small" },
-                style: {
-                    fontSize: "13px",
-                },
-            },
-            {
-                props: { variant: "selected" },
-                style: {
-                    backgroundColor: "rgba(16,86,190,0.1)",
-                    color: theme.palette.primary.main,
-                    boxShadow: theme.shadows[2],
-                    padding: "8px 22px",
-                    "&:hover": {
-                        backgroundColor: "rgba(16,86,190,0.2)",
+        },
+        MuiToggleButton: {
+            styleOverrides: {
+                root: {
+                    minWidth: "fit-content",
+                    height: "fit-content",
+                    "&.MuiToggleButton-sizeSmall": {
+                        lineHeight: defaultLineHeight,
+                        paddingTop: theme.spacing(1),
+                        paddingBottom: theme.spacing(1),
                     },
                     "&.Mui-disabled": {
                         color: theme.palette.primary.main,
@@ -43,12 +124,7 @@ const buttons = (theme: Theme) => {
                     },
                 },
             },
-        ],
-    };
-
-    return {
-        MuiButton: config,
-        MuiToggleButton: config,
+        },
     };
 };
 

--- a/src/theme/components/buttons.ts
+++ b/src/theme/components/buttons.ts
@@ -4,75 +4,47 @@ const buttons = (
     theme: Theme,
     commonSettings: {
         sizes: {
-            input: {
-                defaultLineHeight: string;
-                largeLineHeight: string;
+            button: {
+                height: {
+                    small: string;
+                    medium: string;
+                    large: string;
+                };
+                icon: {
+                    small: string;
+                    medium: string;
+                    large: string;
+                };
+                startIcon: {
+                    small: string;
+                    medium: string;
+                    large: string;
+                };
             };
         };
     },
 ) => {
-    const { defaultLineHeight, largeLineHeight } = commonSettings.sizes.input;
-
-    const buttonPaddings = {
-        unbordered: {
-            small: {
-                paddingTop: `calc(${theme.spacing(1)} + 1px)`,
-                paddingBottom: `calc(${theme.spacing(1)} + 1px)`,
-                paddingLeft: `calc(${theme.spacing(1.5)} + 1px)`,
-                paddingRight: `calc(${theme.spacing(1.5)} + 1px)`,
-            },
-            medium: {
-                paddingTop: `calc(${theme.spacing(1.5)} + 1px)`,
-                paddingBottom: `calc(${theme.spacing(1.5)} + 1px)`,
-                paddingLeft: `calc(${theme.spacing(2)} + 1px)`,
-                paddingRight: `calc(${theme.spacing(2)} + 1px)`,
-            },
-            large: {
-                paddingTop: `calc(${theme.spacing(2)} + 1px)`,
-                paddingBottom: `calc(${theme.spacing(2)} + 1px)`,
-                paddingLeft: `calc(${theme.spacing(2.5)} + 1px)`,
-                paddingRight: `calc(${theme.spacing(2.5)} + 1px)`,
-            },
-        },
-        bordered: {
-            small: {
-                paddingTop: theme.spacing(1),
-                paddingBottom: theme.spacing(1),
-                paddingLeft: theme.spacing(1.5),
-                paddingRight: theme.spacing(1.5),
-            },
-            medium: {
-                paddingTop: theme.spacing(1.5),
-                paddingBottom: theme.spacing(1.5),
-                paddingLeft: theme.spacing(2),
-                paddingRight: theme.spacing(2),
-            },
-            large: {
-                paddingTop: theme.spacing(2),
-                paddingBottom: theme.spacing(2),
-                paddingLeft: theme.spacing(2.5),
-                paddingRight: theme.spacing(2.5),
-            },
-        },
-    };
-
     return {
-        MuiIconButton: {
+        MuiToggleButton: {
             styleOverrides: {
                 root: {
                     minWidth: "fit-content",
                     height: "fit-content",
-                    "&.MuiIconButton-sizeSmall": {
-                        padding: `calc(${theme.spacing(1)} - .5px)`,
+                    "&.MuiToggleButton-sizeSmall": {
+                        height: commonSettings.sizes.button.height.small,
                     },
-                    "&.MuiIconButton-sizeMedium": {
-                        padding: `calc(${theme.spacing(1.5)} - .5px)`,
+                    "&.MuiToggleButton-sizeMedium": {
+                        height: commonSettings.sizes.button.height.medium,
                     },
-                    "&.MuiIconButton-sizeLarge": {
-                        padding: `calc(${theme.spacing(2)} - 5px)`,
+                    "&.MuiToggleButton-sizeLarge": {
+                        height: commonSettings.sizes.button.height.large,
                     },
-                    "&.MuiIconButton-root .MuiSvgIcon-root": {
-                        fontSize: "24px",
+                    // small/medium icons
+                    "&.MuiToggleButton-root .MuiSvgIcon-root": {
+                        fontSize: commonSettings.sizes.button.icon.medium,
+                    },
+                    "&.MuiToggleButton-sizeLarge .MuiSvgIcon-root": {
+                        fontSize: commonSettings.sizes.button.icon.large,
                     },
                 },
             },
@@ -84,82 +56,57 @@ const buttons = (
                     height: "fit-content",
                     // b/c of https://github.com/material-components/material-components-web/issues/4894
                     whiteSpace: "nowrap",
-                    // small sizing
+                    // fixed heights for all sizes
                     "&.MuiButton-sizeSmall": {
-                        lineHeight: defaultLineHeight,
+                        height: commonSettings.sizes.button.height.small,
                     },
-                    "&.MuiButton-outlined.MuiButton-sizeSmall": {
-                        ...buttonPaddings.bordered.small,
-                    },
-                    "&.MuiButton-contained.MuiButton-sizeSmall": {
-                        ...buttonPaddings.unbordered.small,
-                    },
-                    "&.MuiButton-text.MuiButton-sizeSmall": {
-                        ...buttonPaddings.unbordered.small,
-                    },
-                    // medium sizing
                     "&.MuiButton-sizeMedium": {
-                        lineHeight: defaultLineHeight,
+                        height: commonSettings.sizes.button.height.medium,
                     },
-                    "&.MuiButton-outlined.MuiButton-sizeMedium": {
-                        ...buttonPaddings.bordered.medium,
-                    },
-                    "&.MuiButton-contained.MuiButton-sizeMedium": {
-                        ...buttonPaddings.unbordered.medium,
-                    },
-                    "&.MuiButton-text.MuiButton-sizeMedium": {
-                        ...buttonPaddings.unbordered.medium,
-                    },
-                    // large sizing
                     "&.MuiButton-sizeLarge": {
-                        lineHeight: largeLineHeight,
+                        height: commonSettings.sizes.button.height.large,
                     },
-                    "&.MuiButton-outlined.MuiButton-sizeLarge": {
-                        ...buttonPaddings.bordered.large,
-                    },
-                    "&.MuiButton-contained.MuiButton-sizeLarge": {
-                        ...buttonPaddings.unbordered.large,
-                    },
-                    "&.MuiButton-text.MuiButton-sizeLarge": {
-                        ...buttonPaddings.unbordered.large,
-                    },
-                    // small/medium icons
+                    // change icon size to prevent icon from increasing button size
                     "&.MuiButton-root .MuiSvgIcon-root": {
-                        fontSize: defaultLineHeight,
-                        lineHeight: defaultLineHeight,
+                        fontSize: commonSettings.sizes.button.icon.medium,
                     },
-                    // large icons
-                    "&.MuiButton-sizeLarge .MuiSvgIcon-root": {
-                        fontSize: largeLineHeight,
-                        lineHeight: largeLineHeight,
+                    "&.MuiButton-sizeSmall .MuiSvgIcon-root": {
+                        fontSize: commonSettings.sizes.button.icon.small,
+                    },
+                    "&.MuiButton-sizeSmall .MuiButton-startIcon .MuiSvgIcon-root": {
+                        fontSize: commonSettings.sizes.button.startIcon.small,
+                    },
+                    "&.MuiButton-sizeSmall .MuiButton-endIcon .MuiSvgIcon-root": {
+                        fontSize: commonSettings.sizes.button.startIcon.small,
+                    },
+                    "&.MuiButton-sizeMedium .MuiButton-startIcon .MuiSvgIcon-root": {
+                        fontSize: commonSettings.sizes.button.startIcon.medium,
+                    },
+                    "&.MuiButton-sizeMedium .MuiButton-endIcon .MuiSvgIcon-root": {
+                        fontSize: commonSettings.sizes.button.startIcon.medium,
+                    },
+                    "&.MuiButton-sizeLarge .MuiButton-startIcon .MuiSvgIcon-root": {
+                        fontSize: commonSettings.sizes.button.startIcon.large,
+                    },
+                    "&.MuiButton-sizeLarge .MuiButton-endIcon .MuiSvgIcon-root": {
+                        fontSize: commonSettings.sizes.button.startIcon.large,
                     },
                 },
             },
         },
-        MuiToggleButton: {
+        MuiIconButton: {
             styleOverrides: {
                 root: {
                     minWidth: "fit-content",
                     height: "fit-content",
-                    "&.MuiToggleButton-sizeSmall": {
-                        lineHeight: defaultLineHeight,
-                        ...buttonPaddings.bordered.small,
+                    "&.MuiIconButton-sizeSmall .MuiSvgIcon-root": {
+                        fontSize: commonSettings.sizes.button.icon.small,
                     },
-                    "&.MuiToggleButton-sizeMedium": {
-                        ...buttonPaddings.bordered.medium,
+                    "&.MuiIconButton-sizeMedium .MuiSvgIcon-root": {
+                        fontSize: commonSettings.sizes.button.icon.medium,
                     },
-                    "&.MuiToggleButton-sizeLarge": {
-                        ...buttonPaddings.bordered.large,
-                    },
-                    // small/medium icons
-                    "&.MuiToggleButton-root .MuiSvgIcon-root": {
-                        fontSize: defaultLineHeight,
-                        lineHeight: defaultLineHeight,
-                    },
-                    // large icons
-                    "&.MuiToggleButton-sizeLarge .MuiSvgIcon-root": {
-                        fontSize: largeLineHeight,
-                        lineHeight: largeLineHeight,
+                    "&.MuiIconButton-sizeLarge .MuiSvgIcon-root": {
+                        fontSize: commonSettings.sizes.button.icon.large,
                     },
                 },
             },

--- a/src/theme/components/buttons.ts
+++ b/src/theme/components/buttons.ts
@@ -13,6 +13,49 @@ const buttons = (
 ) => {
     const { defaultLineHeight, largeLineHeight } = commonSettings.sizes.input;
 
+    const buttonPaddings = {
+        unbordered: {
+            small: {
+                paddingTop: `calc(${theme.spacing(1)} + 1px)`,
+                paddingBottom: `calc(${theme.spacing(1)} + 1px)`,
+                paddingLeft: `calc(${theme.spacing(1.5)} + 1px)`,
+                paddingRight: `calc(${theme.spacing(1.5)} + 1px)`,
+            },
+            medium: {
+                paddingTop: `calc(${theme.spacing(1.5)} + 1px)`,
+                paddingBottom: `calc(${theme.spacing(1.5)} + 1px)`,
+                paddingLeft: `calc(${theme.spacing(2)} + 1px)`,
+                paddingRight: `calc(${theme.spacing(2)} + 1px)`,
+            },
+            large: {
+                paddingTop: `calc(${theme.spacing(2)} + 1px)`,
+                paddingBottom: `calc(${theme.spacing(2)} + 1px)`,
+                paddingLeft: `calc(${theme.spacing(2.5)} + 1px)`,
+                paddingRight: `calc(${theme.spacing(2.5)} + 1px)`,
+            },
+        },
+        bordered: {
+            small: {
+                paddingTop: theme.spacing(1),
+                paddingBottom: theme.spacing(1),
+                paddingLeft: theme.spacing(1.5),
+                paddingRight: theme.spacing(1.5),
+            },
+            medium: {
+                paddingTop: theme.spacing(1.5),
+                paddingBottom: theme.spacing(1.5),
+                paddingLeft: theme.spacing(2),
+                paddingRight: theme.spacing(2),
+            },
+            large: {
+                paddingTop: theme.spacing(2),
+                paddingBottom: theme.spacing(2),
+                paddingLeft: theme.spacing(2.5),
+                paddingRight: theme.spacing(2.5),
+            },
+        },
+    };
+
     return {
         MuiIconButton: {
             styleOverrides: {
@@ -41,64 +84,46 @@ const buttons = (
                     height: "fit-content",
                     // b/c of https://github.com/material-components/material-components-web/issues/4894
                     whiteSpace: "nowrap",
+                    // small sizing
                     "&.MuiButton-sizeSmall": {
                         lineHeight: defaultLineHeight,
-                        paddingTop: theme.spacing(1),
-                        paddingBottom: theme.spacing(1),
-                        paddingLeft: theme.spacing(1.5),
-                        paddingRight: theme.spacing(1.5),
+                    },
+                    "&.MuiButton-outlined.MuiButton-sizeSmall": {
+                        ...buttonPaddings.bordered.small,
                     },
                     "&.MuiButton-contained.MuiButton-sizeSmall": {
-                        paddingTop: `calc(${theme.spacing(1)} + 1px)`,
-                        paddingBottom: `calc(${theme.spacing(1)} + 1px)`,
-                        paddingLeft: `calc(${theme.spacing(1.5)} + 1px)`,
-                        paddingRight: `calc(${theme.spacing(1.5)} + 1px)`,
+                        ...buttonPaddings.unbordered.small,
                     },
                     "&.MuiButton-text.MuiButton-sizeSmall": {
-                        paddingTop: `calc(${theme.spacing(1)} + 1px)`,
-                        paddingBottom: `calc(${theme.spacing(1)} + 1px)`,
-                        paddingLeft: `calc(${theme.spacing(1.5)} + 1px)`,
-                        paddingRight: `calc(${theme.spacing(1.5)} + 1px)`,
+                        ...buttonPaddings.unbordered.small,
                     },
+                    // medium sizing
                     "&.MuiButton-sizeMedium": {
                         lineHeight: defaultLineHeight,
-                        paddingTop: theme.spacing(1.5),
-                        paddingBottom: theme.spacing(1.5),
-                        paddingLeft: theme.spacing(2),
-                        paddingRight: theme.spacing(2),
+                    },
+                    "&.MuiButton-outlined.MuiButton-sizeMedium": {
+                        ...buttonPaddings.bordered.medium,
                     },
                     "&.MuiButton-contained.MuiButton-sizeMedium": {
-                        paddingTop: `calc(${theme.spacing(1.5)} + 1px)`,
-                        paddingBottom: `calc(${theme.spacing(1.5)} + 1px)`,
-                        paddingLeft: `calc(${theme.spacing(2)} + 1px)`,
-                        paddingRight: `calc(${theme.spacing(2)} + 1px)`,
+                        ...buttonPaddings.unbordered.medium,
                     },
                     "&.MuiButton-text.MuiButton-sizeMedium": {
-                        paddingTop: `calc(${theme.spacing(1.5)} + 1px)`,
-                        paddingBottom: `calc(${theme.spacing(1.5)} + 1px)`,
-                        paddingLeft: `calc(${theme.spacing(2)} + 1px)`,
-                        paddingRight: `calc(${theme.spacing(2)} + 1px)`,
+                        ...buttonPaddings.unbordered.medium,
                     },
+                    // large sizing
                     "&.MuiButton-sizeLarge": {
                         lineHeight: largeLineHeight,
-                        paddingTop: theme.spacing(2),
-                        paddingBottom: theme.spacing(2),
-                        paddingLeft: theme.spacing(2.5),
-                        paddingRight: theme.spacing(2.5),
+                    },
+                    "&.MuiButton-outlined.MuiButton-sizeLarge": {
+                        ...buttonPaddings.bordered.large,
                     },
                     "&.MuiButton-contained.MuiButton-sizeLarge": {
-                        paddingTop: `calc(${theme.spacing(2)} + 1px)`,
-                        paddingBottom: `calc(${theme.spacing(2)} + 1px)`,
-                        paddingLeft: `calc(${theme.spacing(2.5)} + 1px)`,
-                        paddingRight: `calc(${theme.spacing(2.5)} + 1px)`,
+                        ...buttonPaddings.unbordered.large,
                     },
                     "&.MuiButton-text.MuiButton-sizeLarge": {
-                        paddingTop: `calc(${theme.spacing(2)} + 1px)`,
-                        paddingBottom: `calc(${theme.spacing(2)} + 1px)`,
-                        paddingLeft: `calc(${theme.spacing(2.5)} + 1px)`,
-                        paddingRight: `calc(${theme.spacing(2.5)} + 1px)`,
+                        ...buttonPaddings.unbordered.large,
                     },
-                    // small and medium icons
+                    // small/medium icons
                     "&.MuiButton-root .MuiSvgIcon-root": {
                         fontSize: defaultLineHeight,
                         lineHeight: defaultLineHeight,
@@ -118,13 +143,31 @@ const buttons = (
                     height: "fit-content",
                     "&.MuiToggleButton-sizeSmall": {
                         lineHeight: defaultLineHeight,
-                        paddingTop: theme.spacing(1),
-                        paddingBottom: theme.spacing(1),
+                        ...buttonPaddings.bordered.small,
                     },
-                    "&.Mui-disabled": {
-                        color: theme.palette.primary.main,
-                        boxShadow: "none",
+                    "&.MuiToggleButton-sizeMedium": {
+                        ...buttonPaddings.bordered.medium,
                     },
+                    "&.MuiToggleButton-sizeLarge": {
+                        ...buttonPaddings.bordered.large,
+                    },
+                    // small/medium icons
+                    "&.MuiToggleButton-root .MuiSvgIcon-root": {
+                        fontSize: defaultLineHeight,
+                        lineHeight: defaultLineHeight,
+                    },
+                    // large icons
+                    "&.MuiToggleButton-sizeLarge .MuiSvgIcon-root": {
+                        fontSize: largeLineHeight,
+                        lineHeight: largeLineHeight,
+                    },
+                },
+            },
+        },
+        MuiButtonGroup: {
+            styleOverrides: {
+                root: {
+                    height: "fit-content",
                 },
             },
         },

--- a/src/theme/components/buttons.ts
+++ b/src/theme/components/buttons.ts
@@ -1,126 +1,111 @@
 import { Theme } from "@mui/material/styles";
 
+type SizeConfig = {
+    height: string;
+    icon: string;
+    startIcon: string;
+    paddingX?: string;
+};
+
+const getButtonSizeStyles = (config: SizeConfig, { includePadding = true, fixedHeight = true }) => {
+    return {
+        ...(fixedHeight && config.height && { height: config.height }),
+        ...(includePadding &&
+            config.paddingX && {
+                paddingLeft: config.paddingX,
+                paddingRight: config.paddingX,
+            }),
+        "& .MuiSvgIcon-root": {
+            fontSize: config.icon,
+        },
+        "& .MuiButton-startIcon .MuiSvgIcon-root, & .MuiButton-endIcon .MuiSvgIcon-root": {
+            fontSize: config.startIcon,
+        },
+    };
+};
+
+const defaultRootStyles = {
+    minWidth: "fit-content",
+    height: "fit-content",
+};
+
 const buttons = (
     theme: Theme,
     commonSettings: {
         sizes: {
             button: {
-                height: {
-                    small: string;
-                    medium: string;
-                    large: string;
-                };
-                icon: {
-                    small: string;
-                    medium: string;
-                    large: string;
-                };
-                startIcon: {
-                    small: string;
-                    medium: string;
-                    large: string;
-                };
+                small: SizeConfig;
+                medium: SizeConfig;
+                large: SizeConfig;
             };
         };
     },
 ) => {
+    const buttonSizeConfig = commonSettings.sizes.button;
     return {
         MuiToggleButton: {
             styleOverrides: {
                 root: {
-                    minWidth: "fit-content",
-                    height: "fit-content",
-                    "&.MuiToggleButton-sizeSmall": {
-                        height: commonSettings.sizes.button.height.small,
-                    },
-                    "&.MuiToggleButton-sizeMedium": {
-                        height: commonSettings.sizes.button.height.medium,
-                    },
-                    "&.MuiToggleButton-sizeLarge": {
-                        height: commonSettings.sizes.button.height.large,
-                    },
-                    // small/medium icons
-                    "&.MuiToggleButton-root .MuiSvgIcon-root": {
-                        fontSize: commonSettings.sizes.button.icon.medium,
-                    },
-                    "&.MuiToggleButton-sizeLarge .MuiSvgIcon-root": {
-                        fontSize: commonSettings.sizes.button.icon.large,
-                    },
+                    ...defaultRootStyles,
+                },
+                sizeSmall: {
+                    ...getButtonSizeStyles(buttonSizeConfig.small, { includePadding: false }),
+                },
+                sizeMedium: {
+                    ...getButtonSizeStyles(buttonSizeConfig.medium, { includePadding: false }),
+                },
+                sizeLarge: {
+                    ...getButtonSizeStyles(buttonSizeConfig.large, { includePadding: false }),
                 },
             },
         },
         MuiButton: {
             styleOverrides: {
                 root: {
-                    minWidth: "fit-content",
-                    height: "fit-content",
+                    ...defaultRootStyles,
                     // b/c of https://github.com/material-components/material-components-web/issues/4894
                     whiteSpace: "nowrap",
-                    // fixed heights for all sizes
-                    "&.MuiButton-sizeSmall": {
-                        height: commonSettings.sizes.button.height.small,
-                        paddingLeft: "10px",
-                        paddingRight: "10px",
-                    },
-                    "&.MuiButton-sizeMedium": {
-                        height: commonSettings.sizes.button.height.medium,
-                        paddingLeft: "16px",
-                        paddingRight: "16px",
-                    },
-                    "&.MuiButton-sizeLarge": {
-                        height: commonSettings.sizes.button.height.large,
-                        paddingLeft: "22px",
-                        paddingRight: "22px",
-                    },
-                    // change icon size to prevent icon from increasing button size
-                    "&.MuiButton-root .MuiSvgIcon-root": {
-                        fontSize: commonSettings.sizes.button.icon.medium,
-                    },
-                    "&.MuiButton-sizeSmall .MuiSvgIcon-root": {
-                        fontSize: commonSettings.sizes.button.icon.small,
-                    },
-                    "&.MuiButton-sizeSmall .MuiButton-startIcon .MuiSvgIcon-root": {
-                        fontSize: commonSettings.sizes.button.startIcon.small,
-                    },
-                    "&.MuiButton-sizeSmall .MuiButton-endIcon .MuiSvgIcon-root": {
-                        fontSize: commonSettings.sizes.button.startIcon.small,
-                    },
-                    "&.MuiButton-sizeMedium .MuiButton-startIcon .MuiSvgIcon-root": {
-                        fontSize: commonSettings.sizes.button.startIcon.medium,
-                    },
-                    "&.MuiButton-sizeMedium .MuiButton-endIcon .MuiSvgIcon-root": {
-                        fontSize: commonSettings.sizes.button.startIcon.medium,
-                    },
-                    "&.MuiButton-sizeLarge .MuiButton-startIcon .MuiSvgIcon-root": {
-                        fontSize: commonSettings.sizes.button.startIcon.large,
-                    },
-                    "&.MuiButton-sizeLarge .MuiButton-endIcon .MuiSvgIcon-root": {
-                        fontSize: commonSettings.sizes.button.startIcon.large,
-                    },
+                },
+                sizeSmall: {
+                    ...getButtonSizeStyles(buttonSizeConfig.small, { includePadding: true }),
+                },
+                sizeMedium: {
+                    ...getButtonSizeStyles(buttonSizeConfig.medium, { includePadding: true }),
+                },
+                sizeLarge: {
+                    ...getButtonSizeStyles(buttonSizeConfig.large, { includePadding: true }),
                 },
             },
         },
         MuiIconButton: {
             styleOverrides: {
                 root: {
-                    minWidth: "fit-content",
-                    height: "fit-content",
-                    "&.MuiIconButton-sizeSmall .MuiSvgIcon-root": {
-                        fontSize: commonSettings.sizes.button.icon.small,
-                    },
-                    "&.MuiIconButton-sizeMedium .MuiSvgIcon-root": {
-                        fontSize: commonSettings.sizes.button.icon.medium,
-                    },
-                    "&.MuiIconButton-sizeLarge .MuiSvgIcon-root": {
-                        fontSize: commonSettings.sizes.button.icon.large,
-                    },
+                    ...defaultRootStyles,
+                },
+                sizeSmall: {
+                    ...getButtonSizeStyles(buttonSizeConfig.small, {
+                        includePadding: false,
+                        fixedHeight: false,
+                    }),
+                },
+                sizeMedium: {
+                    ...getButtonSizeStyles(buttonSizeConfig.medium, {
+                        includePadding: false,
+                        fixedHeight: false,
+                    }),
+                },
+                sizeLarge: {
+                    ...getButtonSizeStyles(buttonSizeConfig.large, {
+                        includePadding: false,
+                        fixedHeight: false,
+                    }),
                 },
             },
         },
         MuiButtonGroup: {
             styleOverrides: {
                 root: {
-                    height: "fit-content",
+                    ...defaultRootStyles,
                 },
             },
         },

--- a/src/theme/components/cssBaseline.ts
+++ b/src/theme/components/cssBaseline.ts
@@ -1,0 +1,15 @@
+// Used to make scrollbars dark in dark mode per https://mui.com/material-ui/react-css-baseline/#scrollbars
+
+import { darkScrollbar } from "@mui/material";
+import { Theme } from "@mui/material/styles";
+
+// Otherwise, b/c the Dialogs are appended to the body, they will have light scrollbars in dark mode
+const cssBaseline = () => ({
+    MuiCssBaseline: {
+        styleOverrides: (themeParam: Theme) => ({
+            body: themeParam.palette.mode === "dark" ? darkScrollbar() : null,
+        }),
+    },
+});
+
+export default cssBaseline;

--- a/src/theme/components/icons.ts
+++ b/src/theme/components/icons.ts
@@ -1,0 +1,26 @@
+const icons = () => ({
+    MuiSvgIcon: {
+        variants: [
+            {
+                props: { fontSize: "small" },
+                style: {
+                    fontSize: "1.125rem",
+                },
+            },
+            {
+                props: { fontSize: "medium" },
+                style: {
+                    fontSize: "1.25rem",
+                },
+            },
+            {
+                props: { fontSize: "large" },
+                style: {
+                    fontSize: "2.1875px",
+                },
+            },
+        ],
+    },
+});
+
+export default icons;

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -1,0 +1,8 @@
+import buttons from "./buttons";
+import chips from "./chips";
+import cssBaseline from "./cssBaseline";
+import icons from "./icons";
+import inputs from "./inputs";
+import tooltips from "./tooltips";
+
+export { buttons, chips, cssBaseline, icons, inputs, tooltips };

--- a/src/theme/components/inputs.ts
+++ b/src/theme/components/inputs.ts
@@ -1,36 +1,84 @@
 import { Theme } from "@mui/material/styles";
 
+// MUI uses fixed pixel values for most of this, so we override them to achieve the desired appearance at different sizes.
+const inputSizes = {
+    small: {
+        paddingTop: "12px",
+        paddingBottom: "5px",
+        textField: {
+            marginTop: "11px",
+        },
+        chip: {
+            height: "23px",
+        },
+        label: {
+            translateDown: "8.5px",
+        },
+        outlined: {
+            paddingTop: "8.5px",
+            paddingBottom: "8.5px",
+        },
+        autoComplete: {
+            paddingTop: "5px",
+            paddingBottom: "5px",
+        },
+    },
+    medium: {
+        paddingTop: "20px",
+        paddingBottom: "5px",
+        textField: {
+            marginTop: "11px",
+        },
+        chip: {
+            height: "23px",
+        },
+        label: {
+            translateDown: "12.5px",
+        },
+        outlined: {
+            paddingTop: "12.5px",
+            paddingBottom: "12.5px",
+        },
+        autoComplete: {
+            paddingTop: "6px",
+            paddingBottom: "6px",
+        },
+    },
+};
+
 const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme["components"] => {
     return {
         MuiInputBase: {
             styleOverrides: {
                 root: {
                     minWidth: commonSettings.inputMinWidth,
-                    // Outlined variant
+                    // outlined variant medium
                     "& .MuiOutlinedInput-input": {
-                        paddingTop: `calc(${theme.spacing(1.5)} + 0.5px)`,
-                        paddingBottom: `calc(${theme.spacing(1.5)} + 0.5px)`,
+                        paddingTop: inputSizes.medium.outlined.paddingTop,
+                        paddingBottom: inputSizes.medium.outlined.paddingBottom,
                     },
+                    // outlined variant small
                     "&.MuiInputBase-sizeSmall .MuiOutlinedInput-input": {
-                        paddingTop: `calc(${theme.spacing(1)} + 0.5px)`,
-                        paddingBottom: `calc(${theme.spacing(1)} + 0.5px)`,
+                        paddingTop: inputSizes.small.outlined.paddingTop,
+                        paddingBottom: inputSizes.small.outlined.paddingBottom,
                     },
-                    // Underlined variant
-                    "&.MuiInputBase-sizeSmall.MuiInput-underline": {
-                        marginTop: "11px",
-                    },
-                    // Filled variant
+                    // filled variant medium
                     "& .MuiFilledInput-input": {
-                        paddingTop: "18px",
-                        paddingBottom: "7px",
+                        paddingTop: inputSizes.medium.paddingTop,
+                        paddingBottom: inputSizes.medium.paddingBottom,
                     },
+                    // filled variant small
                     "&.MuiInputBase-sizeSmall .MuiFilledInput-input": {
-                        paddingTop: "14px",
-                        paddingBottom: "3px",
+                        paddingTop: inputSizes.small.paddingTop,
+                        paddingBottom: inputSizes.small.paddingBottom,
+                    },
+                    // underlined variant small
+                    "&.MuiInputBase-sizeSmall.MuiInput-underline": {
+                        marginTop: inputSizes.small.textField.marginTop,
                     },
                     // Chips
                     "& .MuiInputBase-input .MuiChip-root": {
-                        height: "23px",
+                        height: inputSizes.small.chip.height,
                     },
                 },
             },
@@ -38,15 +86,19 @@ const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme[
         MuiInputLabel: {
             styleOverrides: {
                 root: {
-                    "&.MuiInputLabel-sizeSmall": {
-                        transform: `translate(14px, 8px) scale(1)`,
-                    },
+                    // all variants medium
                     "&.MuiInputLabel-sizeMedium": {
-                        transform: `translate(14px, 13px) scale(1)`,
+                        transform: `translate(14px, ${inputSizes.medium.label.translateDown}) scale(1)`,
+                    },
+                    // all variants small
+                    "&.MuiInputLabel-sizeSmall": {
+                        transform: `translate(14px, ${inputSizes.small.label.translateDown}) scale(1)`,
                     },
                 },
                 shrink: {
+                    // all variants all sizes
                     "&.MuiInputLabel-shrink.MuiInputLabel-root": {
+                        // use 0.5em to achieve better behavior on font size changes
                         transform: "translate(14px, -0.5em) scale(0.75)",
                     },
                 },
@@ -56,16 +108,19 @@ const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme[
             styleOverrides: {
                 root: {
                     minWidth: commonSettings.inputMinWidth,
+                    // standard variant small
                     "&.MuiInputBase-sizeSmall.MuiInput-underline": {
-                        marginTop: "11px",
+                        marginTop: inputSizes.small.textField.marginTop,
                     },
+                    // filled variant medium
                     "& .MuiFilledInput-input": {
-                        paddingTop: "18px",
-                        paddingBottom: "7px",
+                        paddingTop: inputSizes.medium.paddingTop,
+                        paddingBottom: inputSizes.medium.paddingBottom,
                     },
+                    // filled variant small
                     "&.MuiInputBase-sizeSmall .MuiFilledInput-input": {
-                        paddingTop: "14px",
-                        paddingBottom: "3px",
+                        paddingTop: inputSizes.small.paddingTop,
+                        paddingBottom: inputSizes.small.paddingBottom,
                     },
                 },
             },
@@ -73,20 +128,24 @@ const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme[
         MuiAutocomplete: {
             styleOverrides: {
                 root: {
-                    "& .MuiFilledInput-root": {
-                        paddingTop: "11px",
-                    },
-                    "& .MuiAutocomplete-inputRoot.MuiOutlinedInput-root": {
-                        paddingTop: "5px",
-                        paddingBottom: "5px",
-                    },
-                    "&.MuiInputBase-sizeSmall .MuiFilledInput-input": {
-                        paddingTop: "14px",
-                        paddingBottom: "3px",
-                    },
+                    // default small
                     "& .MuiInputBase-sizeSmall.MuiAutocomplete-inputRoot.MuiOutlinedInput-root": {
-                        paddingTop: "6px",
-                        paddingBottom: "6px",
+                        paddingTop: inputSizes.small.autoComplete.paddingTop,
+                        paddingBottom: inputSizes.small.autoComplete.paddingBottom,
+                    },
+                    // default medium
+                    "& .MuiAutocomplete-inputRoot.MuiOutlinedInput-root": {
+                        paddingTop: inputSizes.medium.autoComplete.paddingTop,
+                        paddingBottom: inputSizes.medium.autoComplete.paddingBottom,
+                    },
+                    // filled variant small
+                    "&.MuiInputBase-sizeSmall .MuiFilledInput-input": {
+                        paddingTop: inputSizes.small.paddingTop,
+                        paddingBottom: inputSizes.small.paddingBottom,
+                    },
+                    // filled variant medium
+                    "& .MuiFilledInput-root": {
+                        paddingTop: inputSizes.medium.textField.marginTop,
                     },
                 },
             },

--- a/src/theme/components/inputs.ts
+++ b/src/theme/components/inputs.ts
@@ -50,104 +50,105 @@ const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme[
     return {
         MuiInputBase: {
             styleOverrides: {
-                root: {
+                root: ({ ownerState }) => ({
                     minWidth: commonSettings.inputMinWidth,
-                    // outlined variant medium
-                    "& .MuiOutlinedInput-input": {
-                        paddingTop: inputSizes.medium.outlined.paddingTop,
-                        paddingBottom: inputSizes.medium.outlined.paddingBottom,
+                    "& .MuiInputBase-input": {
+                        // Check for size and variant
+                        ...(ownerState.size === "small" &&
+                            ownerState.variant === "outlined" && {
+                                paddingTop: inputSizes.small.outlined.paddingTop,
+                                paddingBottom: inputSizes.small.outlined.paddingBottom,
+                            }),
+                        ...(ownerState.size === "small" &&
+                            ownerState.variant === "filled" && {
+                                paddingTop: inputSizes.small.paddingTop,
+                                paddingBottom: inputSizes.small.paddingBottom,
+                            }),
+                        ...(ownerState.size === "small" &&
+                            ownerState.variant === "standard" && {
+                                marginTop: inputSizes.small.textField.marginTop,
+                            }),
+                        ...(ownerState.size === "medium" &&
+                            ownerState.variant === "outlined" && {
+                                paddingTop: inputSizes.medium.outlined.paddingTop,
+                                paddingBottom: inputSizes.medium.outlined.paddingBottom,
+                            }),
+                        ...(ownerState.size === "medium" &&
+                            ownerState.variant === "filled" && {
+                                paddingTop: inputSizes.medium.paddingTop,
+                                paddingBottom: inputSizes.medium.paddingBottom,
+                            }),
+
+                        "& .MuiChip-root": {
+                            height: inputSizes.small.chip.height,
+                        },
                     },
-                    // outlined variant small
-                    "&.MuiInputBase-sizeSmall .MuiOutlinedInput-input": {
-                        paddingTop: inputSizes.small.outlined.paddingTop,
-                        paddingBottom: inputSizes.small.outlined.paddingBottom,
-                    },
-                    // filled variant medium
-                    "& .MuiFilledInput-input": {
-                        paddingTop: inputSizes.medium.paddingTop,
-                        paddingBottom: inputSizes.medium.paddingBottom,
-                    },
-                    // filled variant small
-                    "&.MuiInputBase-sizeSmall .MuiFilledInput-input": {
-                        paddingTop: inputSizes.small.paddingTop,
-                        paddingBottom: inputSizes.small.paddingBottom,
-                    },
-                    // underlined variant small
-                    "&.MuiInputBase-sizeSmall.MuiInput-underline": {
-                        marginTop: inputSizes.small.textField.marginTop,
-                    },
-                    // Chips
-                    "& .MuiInputBase-input .MuiChip-root": {
-                        height: inputSizes.small.chip.height,
-                    },
-                },
+                }),
             },
         },
         MuiInputLabel: {
             styleOverrides: {
-                root: {
-                    // all variants medium
-                    "&.MuiInputLabel-sizeMedium": {
+                root: ({ ownerState }) => ({
+                    ...(ownerState.size === "normal" && {
                         transform: `translate(14px, ${inputSizes.medium.label.translateDown}) scale(1)`,
-                    },
-                    // all variants small
-                    "&.MuiInputLabel-sizeSmall": {
+                    }),
+                    ...(ownerState.size === "small" && {
                         transform: `translate(14px, ${inputSizes.small.label.translateDown}) scale(1)`,
-                    },
-                },
+                    }),
+                }),
                 shrink: {
-                    // all variants all sizes
-                    "&.MuiInputLabel-shrink.MuiInputLabel-root": {
-                        // use 0.5em to achieve better behavior on font size changes
-                        transform: "translate(14px, -0.5em) scale(0.75)",
-                    },
+                    transform: "translate(14px, -0.5em) scale(0.75)",
                 },
             },
         },
         MuiTextField: {
             styleOverrides: {
-                root: {
+                root: ({ ownerState }) => ({
                     minWidth: commonSettings.inputMinWidth,
-                    // standard variant small
-                    "&.MuiInputBase-sizeSmall.MuiInput-underline": {
+                    ...(ownerState.size === "small" && {
                         marginTop: inputSizes.small.textField.marginTop,
+                    }),
+                    ".MuiInputBase-input": {
+                        ...(ownerState.size === "medium" &&
+                            ownerState.variant === "filled" && {
+                                paddingTop: inputSizes.medium.paddingTop,
+                                paddingBottom: inputSizes.medium.paddingBottom,
+                            }),
+                        ...(ownerState.size === "small" &&
+                            ownerState.variant === "filled" && {
+                                paddingTop: inputSizes.small.paddingTop,
+                                paddingBottom: inputSizes.small.paddingBottom,
+                            }),
                     },
-                    // filled variant medium
-                    "& .MuiFilledInput-input": {
-                        paddingTop: inputSizes.medium.paddingTop,
-                        paddingBottom: inputSizes.medium.paddingBottom,
-                    },
-                    // filled variant small
-                    "&.MuiInputBase-sizeSmall .MuiFilledInput-input": {
-                        paddingTop: inputSizes.small.paddingTop,
-                        paddingBottom: inputSizes.small.paddingBottom,
-                    },
-                },
+                }),
             },
         },
         MuiAutocomplete: {
             styleOverrides: {
-                root: {
-                    // default small
-                    "& .MuiInputBase-sizeSmall.MuiAutocomplete-inputRoot.MuiOutlinedInput-root": {
-                        paddingTop: inputSizes.small.autoComplete.paddingTop,
-                        paddingBottom: inputSizes.small.autoComplete.paddingBottom,
+                root: ({ ownerState }) => ({
+                    "& .MuiInputBase-root": {
+                        ...(ownerState.size === "small" &&
+                            ownerState.variant === "outlined" && {
+                                paddingTop: inputSizes.small.autoComplete.paddingTop,
+                                paddingBottom: inputSizes.small.autoComplete.paddingBottom,
+                            }),
+                        ...(ownerState.size === "small" &&
+                            ownerState.variant === "filled" && {
+                                paddingTop: inputSizes.small.autoComplete.paddingTop,
+                                paddingBottom: inputSizes.small.autoComplete.paddingBottom,
+                            }),
+                        ...(ownerState.size === "medium" &&
+                            ownerState.variant === "outlined" && {
+                                paddingTop: inputSizes.medium.autoComplete.paddingTop,
+                                paddingBottom: inputSizes.medium.autoComplete.paddingBottom,
+                            }),
+                        ...(ownerState.size === "medium" &&
+                            ownerState.variant === "filled" && {
+                                paddingTop: inputSizes.medium.autoComplete.paddingTop,
+                                paddingBottom: inputSizes.medium.autoComplete.paddingBottom,
+                            }),
                     },
-                    // default medium
-                    "& .MuiAutocomplete-inputRoot.MuiOutlinedInput-root": {
-                        paddingTop: inputSizes.medium.autoComplete.paddingTop,
-                        paddingBottom: inputSizes.medium.autoComplete.paddingBottom,
-                    },
-                    // filled variant small
-                    "&.MuiInputBase-sizeSmall .MuiFilledInput-input": {
-                        paddingTop: inputSizes.small.paddingTop,
-                        paddingBottom: inputSizes.small.paddingBottom,
-                    },
-                    // filled variant medium
-                    "& .MuiFilledInput-root": {
-                        paddingTop: inputSizes.medium.textField.marginTop,
-                    },
-                },
+                }),
             },
         },
     };

--- a/src/theme/components/inputs.ts
+++ b/src/theme/components/inputs.ts
@@ -28,6 +28,10 @@ const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme[
                         paddingTop: "14px",
                         paddingBottom: "3px",
                     },
+                    // Chips
+                    "& .MuiInputBase-input .MuiChip-root": {
+                        height: "23px",
+                    },
                 },
             },
         },

--- a/src/theme/components/inputs.ts
+++ b/src/theme/components/inputs.ts
@@ -12,15 +12,15 @@ const inputSizes = {
             height: "23px",
         },
         label: {
-            translateDown: "8.5px",
+            translateDown: "7px",
         },
         outlined: {
             paddingTop: "8.5px",
             paddingBottom: "8.5px",
         },
         autoComplete: {
-            paddingTop: "5px",
-            paddingBottom: "5px",
+            paddingTop: "6px",
+            paddingBottom: "6px",
         },
     },
     medium: {
@@ -33,15 +33,15 @@ const inputSizes = {
             height: "23px",
         },
         label: {
-            translateDown: "12.5px",
+            translateDown: "13px",
         },
         outlined: {
             paddingTop: "12.5px",
             paddingBottom: "12.5px",
         },
         autoComplete: {
-            paddingTop: "6px",
-            paddingBottom: "6px",
+            paddingTop: "5px",
+            paddingBottom: "5px",
         },
     },
 };

--- a/src/theme/components/inputs.ts
+++ b/src/theme/components/inputs.ts
@@ -18,6 +18,10 @@ const inputSizes = {
             paddingTop: "8.5px",
             paddingBottom: "8.5px",
         },
+        standard: {
+            paddingTop: "1px",
+            paddingBottom: "5px",
+        },
         autoComplete: {
             paddingTop: "6px",
             paddingBottom: "6px",
@@ -27,7 +31,7 @@ const inputSizes = {
         paddingTop: "20px",
         paddingBottom: "5px",
         textField: {
-            marginTop: "11px",
+            marginTop: "16px",
         },
         chip: {
             height: "23px",
@@ -38,6 +42,10 @@ const inputSizes = {
         outlined: {
             paddingTop: "12.5px",
             paddingBottom: "12.5px",
+        },
+        standard: {
+            paddingTop: "4px",
+            paddingBottom: "5px",
         },
         autoComplete: {
             paddingTop: "5px",
@@ -53,35 +61,14 @@ const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme[
                 root: ({ ownerState }) => ({
                     minWidth: commonSettings.inputMinWidth,
                     "& .MuiInputBase-input": {
-                        // Check for size and variant
-                        ...(ownerState.size === "small" &&
-                            ownerState.variant === "outlined" && {
-                                paddingTop: inputSizes.small.outlined.paddingTop,
-                                paddingBottom: inputSizes.small.outlined.paddingBottom,
-                            }),
-                        ...(ownerState.size === "small" &&
-                            ownerState.variant === "filled" && {
-                                paddingTop: inputSizes.small.paddingTop,
-                                paddingBottom: inputSizes.small.paddingBottom,
-                            }),
-                        ...(ownerState.size === "small" &&
-                            ownerState.variant === "standard" && {
-                                marginTop: inputSizes.small.textField.marginTop,
-                            }),
-                        ...(ownerState.size === "medium" &&
-                            ownerState.variant === "outlined" && {
-                                paddingTop: inputSizes.medium.outlined.paddingTop,
-                                paddingBottom: inputSizes.medium.outlined.paddingBottom,
-                            }),
-                        ...(ownerState.size === "medium" &&
-                            ownerState.variant === "filled" && {
-                                paddingTop: inputSizes.medium.paddingTop,
-                                paddingBottom: inputSizes.medium.paddingBottom,
-                            }),
-
-                        "& .MuiChip-root": {
-                            height: inputSizes.small.chip.height,
-                        },
+                        ...(ownerState.size === "small" && {
+                            paddingTop: inputSizes.small.outlined.paddingTop,
+                            paddingBottom: inputSizes.small.outlined.paddingBottom,
+                        }),
+                        ...(ownerState.size === "medium" && {
+                            paddingTop: inputSizes.medium.outlined.paddingTop,
+                            paddingBottom: inputSizes.medium.outlined.paddingBottom,
+                        }),
                     },
                 }),
             },
@@ -89,66 +76,127 @@ const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme[
         MuiInputLabel: {
             styleOverrides: {
                 root: ({ ownerState }) => ({
-                    ...(ownerState.size === "normal" && {
-                        transform: `translate(14px, ${inputSizes.medium.label.translateDown}) scale(1)`,
-                    }),
-                    ...(ownerState.size === "small" && {
-                        transform: `translate(14px, ${inputSizes.small.label.translateDown}) scale(1)`,
-                    }),
+                    ...(ownerState.size === "small" &&
+                        ownerState.variant !== "standard" && {
+                            transform: `translate(14px, ${inputSizes.small.label.translateDown}) scale(1)`,
+                        }),
+                    // @ts-ignore
+                    ...(ownerState.size === "medium" &&
+                        ownerState.variant !== "standard" && {
+                            transform: `translate(14px, ${inputSizes.medium.label.translateDown}) scale(1)`,
+                        }),
                 }),
-                shrink: {
-                    transform: "translate(14px, -0.5em) scale(0.75)",
-                },
+                shrink: ({ ownerState }) => ({
+                    ...(ownerState.variant === "standard"
+                        ? {
+                              transform: "translate(0px, -0.5em) scale(0.75)",
+                          }
+                        : {
+                              transform: "translate(14px, -0.5em) scale(0.75)",
+                          }),
+                }),
             },
         },
         MuiTextField: {
             styleOverrides: {
-                root: ({ ownerState }) => ({
-                    minWidth: commonSettings.inputMinWidth,
-                    ...(ownerState.size === "small" && {
-                        marginTop: inputSizes.small.textField.marginTop,
-                    }),
-                    ".MuiInputBase-input": {
-                        ...(ownerState.size === "medium" &&
-                            ownerState.variant === "filled" && {
-                                paddingTop: inputSizes.medium.paddingTop,
-                                paddingBottom: inputSizes.medium.paddingBottom,
-                            }),
-                        ...(ownerState.size === "small" &&
-                            ownerState.variant === "filled" && {
-                                paddingTop: inputSizes.small.paddingTop,
-                                paddingBottom: inputSizes.small.paddingBottom,
-                            }),
-                    },
-                }),
+                root: ({ ownerState }) => {
+                    return {
+                        minWidth: commonSettings.inputMinWidth,
+                        "& .MuiInputBase-input": {
+                            ...(ownerState.size === "small" &&
+                                ownerState.variant === "outlined" && {
+                                    paddingTop: inputSizes.small.outlined.paddingTop,
+                                    paddingBottom: inputSizes.small.outlined.paddingBottom,
+                                }),
+                            ...(ownerState.size === "medium" &&
+                                ownerState.variant === "outlined" && {
+                                    paddingTop: inputSizes.medium.outlined.paddingTop,
+                                    paddingBottom: inputSizes.medium.outlined.paddingBottom,
+                                }),
+                            ...(ownerState.size === "small" &&
+                                ownerState.variant === "filled" && {
+                                    paddingTop: inputSizes.small.paddingTop,
+                                    paddingBottom: inputSizes.small.paddingBottom,
+                                }),
+                            ...(ownerState.size === "medium" &&
+                                ownerState.variant === "filled" && {
+                                    paddingTop: inputSizes.medium.paddingTop,
+                                    paddingBottom: inputSizes.medium.paddingBottom,
+                                }),
+                            ...(ownerState.size === "small" &&
+                                ownerState.variant === "standard" && {
+                                    paddingTop: inputSizes.small.standard.paddingTop,
+                                    paddingBottom: inputSizes.small.standard.paddingBottom,
+                                }),
+                            ...(ownerState.size === "medium" &&
+                                ownerState.variant === "standard" && {
+                                    paddingTop: inputSizes.medium.standard.paddingTop,
+                                    paddingBottom: inputSizes.medium.standard.paddingBottom,
+                                }),
+                        },
+                        "& .MuiInputBase-root": {
+                            ...(ownerState.size === "small" &&
+                                ownerState.variant === "standard" && {
+                                    marginTop: "11px",
+                                }),
+                            ...(ownerState.size === "medium" &&
+                                ownerState.variant === "standard" && {
+                                    marginTop: "16px",
+                                }),
+                        },
+                    };
+                },
             },
         },
         MuiAutocomplete: {
             styleOverrides: {
                 root: ({ ownerState }) => ({
-                    "& .MuiInputBase-root": {
-                        ...(ownerState.size === "small" &&
-                            ownerState.variant === "outlined" && {
-                                paddingTop: inputSizes.small.autoComplete.paddingTop,
-                                paddingBottom: inputSizes.small.autoComplete.paddingBottom,
-                            }),
-                        ...(ownerState.size === "small" &&
-                            ownerState.variant === "filled" && {
-                                paddingTop: inputSizes.small.autoComplete.paddingTop,
-                                paddingBottom: inputSizes.small.autoComplete.paddingBottom,
-                            }),
-                        ...(ownerState.size === "medium" &&
-                            ownerState.variant === "outlined" && {
-                                paddingTop: inputSizes.medium.autoComplete.paddingTop,
-                                paddingBottom: inputSizes.medium.autoComplete.paddingBottom,
-                            }),
-                        ...(ownerState.size === "medium" &&
-                            ownerState.variant === "filled" && {
-                                paddingTop: inputSizes.medium.autoComplete.paddingTop,
-                                paddingBottom: inputSizes.medium.autoComplete.paddingBottom,
-                            }),
-                    },
+                    ...(ownerState.size === "small" && {
+                        "& .MuiOutlinedInput-root": {
+                            paddingTop: inputSizes.small.autoComplete.paddingTop,
+                            paddingBottom: inputSizes.small.autoComplete.paddingBottom,
+                        },
+                        "& .MuiFilledInput-root.MuiInputBase-sizeSmall": {
+                            paddingTop: inputSizes.small.autoComplete.paddingTop,
+                            paddingBottom: inputSizes.small.autoComplete.paddingBottom,
+                        },
+                        "& .MuiInput-underline": {
+                            marginTop: inputSizes.small.textField.marginTop,
+                        },
+                    }),
+                    ...(ownerState.size === "medium" && {
+                        "& .MuiOutlinedInput-root": {
+                            paddingTop: inputSizes.medium.autoComplete.paddingTop,
+                            paddingBottom: inputSizes.medium.autoComplete.paddingBottom,
+                        },
+                        "& .MuiFilledInput-root": {
+                            paddingTop: inputSizes.medium.paddingTop,
+                            paddingBottom: inputSizes.medium.paddingBottom,
+                        },
+                        "& .MuiInput-underline": {
+                            marginTop: inputSizes.medium.textField.marginTop,
+                        },
+                    }),
                 }),
+            },
+        },
+        MuiSelect: {
+            styleOverrides: {
+                select: ({ ownerState }) => {
+                    return {
+                        "& .MuiSelect-select": {
+                            paddingTop: inputSizes.medium.outlined.paddingTop,
+                            paddingBottom: inputSizes.medium.outlined.paddingBottom,
+                        },
+                        "&.MuiInputBase-inputSizeSmall .MuiSelect-select": {
+                            paddingTop: inputSizes.small.outlined.paddingTop,
+                            paddingBottom: inputSizes.small.outlined.paddingBottom,
+                        },
+                        "& .MuiChip-root": {
+                            height: inputSizes.small.chip.height,
+                        },
+                    };
+                },
             },
         },
     };

--- a/src/theme/components/inputs.ts
+++ b/src/theme/components/inputs.ts
@@ -72,7 +72,7 @@ const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme[
                     "& .MuiFilledInput-root": {
                         paddingTop: "11px",
                     },
-                    "& .MuiAutocomplete-inputRoot.MuiOutlinedInput-root": {
+                    "& .MuiAutoComplete-inputRoot.MuiOutlinedInput-root": {
                         paddingTop: "5px",
                         paddingBottom: "5px",
                     },
@@ -80,7 +80,7 @@ const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme[
                         paddingTop: "14px",
                         paddingBottom: "3px",
                     },
-                    "& .MuiInputBase-sizeSmall.MuiAutocomplete-inputRoot.MuiOutlinedInput-root": {
+                    "& .MuiInputBase-sizeSmall.MuiAutoComplete-inputRoot.MuiOutlinedInput-root": {
                         paddingTop: "6px",
                         paddingBottom: "6px",
                     },

--- a/src/theme/components/inputs.ts
+++ b/src/theme/components/inputs.ts
@@ -6,13 +6,27 @@ const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme[
             styleOverrides: {
                 root: {
                     minWidth: commonSettings.inputMinWidth,
+                    // Outlined variant
                     "& .MuiOutlinedInput-input": {
-                        paddingTop: theme.spacing(1.5),
-                        paddingBottom: theme.spacing(1.5),
+                        paddingTop: `calc(${theme.spacing(1.5)} + 0.5px)`,
+                        paddingBottom: `calc(${theme.spacing(1.5)} + 0.5px)`,
                     },
                     "&.MuiInputBase-sizeSmall .MuiOutlinedInput-input": {
-                        paddingTop: theme.spacing(1),
-                        paddingBottom: theme.spacing(1),
+                        paddingTop: `calc(${theme.spacing(1)} + 0.5px)`,
+                        paddingBottom: `calc(${theme.spacing(1)} + 0.5px)`,
+                    },
+                    // Underlined variant
+                    "&.MuiInputBase-sizeSmall.MuiInput-underline": {
+                        marginTop: "11px",
+                    },
+                    // Filled variant
+                    "& .MuiFilledInput-input": {
+                        paddingTop: "18px",
+                        paddingBottom: "7px",
+                    },
+                    "&.MuiInputBase-sizeSmall .MuiFilledInput-input": {
+                        paddingTop: "14px",
+                        paddingBottom: "3px",
                     },
                 },
             },
@@ -20,15 +34,15 @@ const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme[
         MuiInputLabel: {
             styleOverrides: {
                 root: {
-                    "&.MuiInputLabel-outlined": {
-                        transform: `translate(14px, ${theme.spacing(1.5)}) scale(1)`,
+                    "&.MuiInputLabel-sizeSmall": {
+                        transform: `translate(14px, 8px) scale(1)`,
                     },
-                    "&.MuiInputLabel-sizeSmall.MuiInputLabel-outlined": {
-                        transform: `translate(14px, ${theme.spacing(1)}) scale(1)`,
+                    "&.MuiInputLabel-sizeMedium": {
+                        transform: `translate(14px, 13px) scale(1)`,
                     },
                 },
                 shrink: {
-                    "&.MuiInputLabel-shrink.MuiInputLabel-outlined": {
+                    "&.MuiInputLabel-shrink.MuiInputLabel-root": {
                         transform: "translate(14px, -0.5em) scale(0.75)",
                     },
                 },
@@ -38,14 +52,37 @@ const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme[
             styleOverrides: {
                 root: {
                     minWidth: commonSettings.inputMinWidth,
+                    "&.MuiInputBase-sizeSmall.MuiInput-underline": {
+                        marginTop: "11px",
+                    },
+                    "& .MuiFilledInput-input": {
+                        paddingTop: "18px",
+                        paddingBottom: "7px",
+                    },
+                    "&.MuiInputBase-sizeSmall .MuiFilledInput-input": {
+                        paddingTop: "14px",
+                        paddingBottom: "3px",
+                    },
                 },
             },
         },
         MuiAutocomplete: {
             styleOverrides: {
                 root: {
-                    "& .MuiAutocomplete-endAdornment .MuiIconButton-root": {
-                        padding: 0,
+                    "& .MuiFilledInput-root": {
+                        paddingTop: "11px",
+                    },
+                    "& .MuiAutocomplete-inputRoot.MuiOutlinedInput-root": {
+                        paddingTop: "5px",
+                        paddingBottom: "5px",
+                    },
+                    "&.MuiInputBase-sizeSmall .MuiFilledInput-input": {
+                        paddingTop: "14px",
+                        paddingBottom: "3px",
+                    },
+                    "& .MuiInputBase-sizeSmall.MuiAutocomplete-inputRoot.MuiOutlinedInput-root": {
+                        paddingTop: "6px",
+                        paddingBottom: "6px",
                     },
                 },
             },

--- a/src/theme/components/inputs.ts
+++ b/src/theme/components/inputs.ts
@@ -72,7 +72,7 @@ const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme[
                     "& .MuiFilledInput-root": {
                         paddingTop: "11px",
                     },
-                    "& .MuiAutoComplete-inputRoot.MuiOutlinedInput-root": {
+                    "& .MuiAutocomplete-inputRoot.MuiOutlinedInput-root": {
                         paddingTop: "5px",
                         paddingBottom: "5px",
                     },
@@ -80,7 +80,7 @@ const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme[
                         paddingTop: "14px",
                         paddingBottom: "3px",
                     },
-                    "& .MuiInputBase-sizeSmall.MuiAutoComplete-inputRoot.MuiOutlinedInput-root": {
+                    "& .MuiInputBase-sizeSmall.MuiAutocomplete-inputRoot.MuiOutlinedInput-root": {
                         paddingTop: "6px",
                         paddingBottom: "6px",
                     },

--- a/src/theme/components/inputs.ts
+++ b/src/theme/components/inputs.ts
@@ -1,38 +1,43 @@
 import { Theme } from "@mui/material/styles";
 
-const inputs = (commonSettings: { inputMinWidth: string }): Theme["components"] => {
+const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme["components"] => {
     return {
         MuiInputBase: {
-            variants: [
-                {
-                    props: { size: "small" },
-                    style: {
-                        paddingTop: "3.5px",
-                        paddingBottom: "3.5px",
-                        fontSize: "13px",
-                    },
-                },
-            ],
-        },
-        MuiInputLabel: {
-            variants: [
-                {
-                    props: { size: "small" },
-                    style: {
-                        fontSize: "13px",
-                        lineHeight: "13px",
-                    },
-                },
-            ],
-        },
-        MuiAutocomplete: {
             styleOverrides: {
                 root: {
-                    "& .MuiOutlinedInput-root.MuiInputBase-sizeSmall": {
-                        paddingTop: "3.5px",
-                        paddingBottom: "3.5px",
+                    minWidth: commonSettings.inputMinWidth,
+                    "& .MuiOutlinedInput-input": {
+                        paddingTop: theme.spacing(1.5),
+                        paddingBottom: theme.spacing(1.5),
                     },
-                    "& .MuiAutocomplete-tag": { margin: "0 !important" },
+                    "&.MuiInputBase-sizeSmall .MuiOutlinedInput-input": {
+                        paddingTop: theme.spacing(1),
+                        paddingBottom: theme.spacing(1),
+                    },
+                },
+            },
+        },
+        MuiInputLabel: {
+            styleOverrides: {
+                root: {
+                    "&.MuiInputLabel-outlined": {
+                        transform: `translate(14px, ${theme.spacing(1.5)}) scale(1)`,
+                    },
+                    "&.MuiInputLabel-sizeSmall.MuiInputLabel-outlined": {
+                        transform: `translate(14px, ${theme.spacing(1)}) scale(1)`,
+                    },
+                },
+                shrink: {
+                    "&.MuiInputLabel-shrink.MuiInputLabel-outlined": {
+                        transform: "translate(14px, -0.5em) scale(0.75)",
+                    },
+                },
+            },
+        },
+        MuiTextField: {
+            styleOverrides: {
+                root: {
+                    minWidth: commonSettings.inputMinWidth,
                 },
             },
         },

--- a/src/theme/components/inputs.ts
+++ b/src/theme/components/inputs.ts
@@ -44,7 +44,7 @@ const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme[
         MuiAutocomplete: {
             styleOverrides: {
                 root: {
-                    "& .MuiAutoComplete-endAdornment .MuiIconButton-root": {
+                    "& .MuiAutocomplete-endAdornment .MuiIconButton-root": {
                         padding: 0,
                     },
                 },

--- a/src/theme/components/inputs.ts
+++ b/src/theme/components/inputs.ts
@@ -41,6 +41,15 @@ const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme[
                 },
             },
         },
+        MuiAutocomplete: {
+            styleOverrides: {
+                root: {
+                    "& .MuiAutoComplete-endAdornment .MuiIconButton-root": {
+                        padding: 0,
+                    },
+                },
+            },
+        },
     };
 };
 

--- a/src/theme/components/inputs.ts
+++ b/src/theme/components/inputs.ts
@@ -12,7 +12,7 @@ const inputSizes = {
             height: "23px",
         },
         label: {
-            translateDown: "7px",
+            translateDown: "8.5px",
         },
         outlined: {
             paddingTop: "8.5px",

--- a/src/theme/components/inputs.ts
+++ b/src/theme/components/inputs.ts
@@ -60,16 +60,6 @@ const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme[
             styleOverrides: {
                 root: ({ ownerState }) => ({
                     minWidth: commonSettings.inputMinWidth,
-                    "& .MuiInputBase-input": {
-                        ...(ownerState.size === "small" && {
-                            paddingTop: inputSizes.small.outlined.paddingTop,
-                            paddingBottom: inputSizes.small.outlined.paddingBottom,
-                        }),
-                        ...(ownerState.size === "medium" && {
-                            paddingTop: inputSizes.medium.outlined.paddingTop,
-                            paddingBottom: inputSizes.medium.outlined.paddingBottom,
-                        }),
-                    },
                 }),
             },
         },
@@ -170,7 +160,7 @@ const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme[
                             paddingBottom: inputSizes.medium.autoComplete.paddingBottom,
                         },
                         "& .MuiFilledInput-root": {
-                            paddingTop: inputSizes.medium.paddingTop,
+                            paddingTop: inputSizes.small.autoComplete.paddingTop,
                             paddingBottom: inputSizes.medium.paddingBottom,
                         },
                         "& .MuiInput-underline": {
@@ -182,18 +172,15 @@ const inputs = (theme: Theme, commonSettings: { inputMinWidth: string }): Theme[
         },
         MuiSelect: {
             styleOverrides: {
-                select: ({ ownerState }) => {
+                root: ({ ownerState }) => {
                     return {
                         "& .MuiSelect-select": {
                             paddingTop: inputSizes.medium.outlined.paddingTop,
                             paddingBottom: inputSizes.medium.outlined.paddingBottom,
                         },
-                        "&.MuiInputBase-inputSizeSmall .MuiSelect-select": {
+                        "& .MuiSelect-select.MuiInputBase-inputSizeSmall": {
                             paddingTop: inputSizes.small.outlined.paddingTop,
                             paddingBottom: inputSizes.small.outlined.paddingBottom,
-                        },
-                        "& .MuiChip-root": {
-                            height: inputSizes.small.chip.height,
                         },
                     };
                 },

--- a/src/theme/palette/index.ts
+++ b/src/theme/palette/index.ts
@@ -1,5 +1,7 @@
 // Note: https://bareynol.github.io/mui-theme-creator/#Dialog can be used to preview theme changes
 
+import { Theme } from "@mui/material/styles";
+
 const primaryColorConfig = {
     main: "#5b37c0",
     // To be better readable on dark backgrounds
@@ -86,13 +88,13 @@ const otherOptions = {
     },
 };
 
-export const paletteLight = {
+export const paletteLight: Partial<Theme["palette"]> = {
     ...otherColorOptions,
     ...otherOptions,
     ...primaryAndSecondaryColorOptionsLight,
 };
 
-export const paletteDark = {
+export const paletteDark: Partial<Theme["palette"]> = {
     ...otherColorOptions,
     ...primaryAndSecondaryColorOptionsDark,
 };

--- a/src/theme/palette/index.ts
+++ b/src/theme/palette/index.ts
@@ -88,13 +88,13 @@ const otherOptions = {
     },
 };
 
-export const paletteLight: Partial<Theme["palette"]> = {
+export const paletteLight = {
     ...otherColorOptions,
     ...otherOptions,
     ...primaryAndSecondaryColorOptionsLight,
 };
 
-export const paletteDark: Partial<Theme["palette"]> = {
+export const paletteDark = {
     ...otherColorOptions,
     ...primaryAndSecondaryColorOptionsDark,
 };

--- a/src/theme/palette/index.ts
+++ b/src/theme/palette/index.ts
@@ -12,22 +12,16 @@ const secondaryColorConfig = {
     main: "#757575",
 };
 
-const primaryAndSecondaryColorOptionsLight = {
-    primary: {
-        main: primaryColorConfig.main,
-    },
-    secondary: {
-        main: secondaryColorConfig.main,
-    },
-};
-const primaryAndSecondaryColorOptionsDark = {
-    primary: {
-        main: primaryColorConfig.lighter,
-    },
-    secondary: {
-        main: secondaryColorConfig.main,
-    },
-};
+const primaryAndSecondaryColorOptionsLight = (theme: Theme) => ({
+    primary: theme.palette.augmentColor({ color: { main: primaryColorConfig.main } }),
+    secondary: theme.palette.augmentColor({ color: { main: secondaryColorConfig.main } }),
+});
+
+const primaryAndSecondaryColorOptionsDark = (theme: Theme) => ({
+    primary: theme.palette.augmentColor({ color: { main: primaryColorConfig.lighter } }),
+    secondary: theme.palette.augmentColor({ color: { main: secondaryColorConfig.main } }),
+});
+
 const otherColorOptions = {
     success: {
         main: "#72E128",
@@ -88,13 +82,14 @@ const otherOptions = {
     },
 };
 
-export const paletteLight = {
+// @ts-ignore
+export const paletteLight = (theme: Theme): Partial<Theme["palette"]> => ({
     ...otherColorOptions,
     ...otherOptions,
-    ...primaryAndSecondaryColorOptionsLight,
-};
+    ...primaryAndSecondaryColorOptionsLight(theme),
+});
 
-export const paletteDark = {
+export const paletteDark = (theme: Theme): Partial<Theme["palette"]> => ({
     ...otherColorOptions,
-    ...primaryAndSecondaryColorOptionsDark,
-};
+    ...primaryAndSecondaryColorOptionsDark(theme),
+});

--- a/src/theme/palette/index.ts
+++ b/src/theme/palette/index.ts
@@ -87,9 +87,11 @@ export const paletteLight = (theme: Theme): Partial<Theme["palette"]> => ({
     ...otherColorOptions,
     ...otherOptions,
     ...primaryAndSecondaryColorOptionsLight(theme),
+    mode: "light",
 });
 
 export const paletteDark = (theme: Theme): Partial<Theme["palette"]> => ({
     ...otherColorOptions,
     ...primaryAndSecondaryColorOptionsDark(theme),
+    mode: "dark",
 });

--- a/src/theme/provider/ThemeProvider.tsx
+++ b/src/theme/provider/ThemeProvider.tsx
@@ -3,7 +3,7 @@ import { Theme } from "@mui/material/styles/createTheme";
 import React from "react";
 
 import { AlertContextProvider } from "../../mui/components/custom/alert/AlertContextProvider";
-import LightMaterialUITheme from "../theme";
+import { LightMaterialUITheme } from "../theme";
 
 /**
  * TODO: will be a good practice to add CSSBaseline component from material-ui

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -53,7 +53,7 @@ const defaultTheme = createTheme();
 
 const createCustomTheme = (
     theme: Theme,
-    palette: Partial<Theme["palette"]>,
+    palette: object,
     typography: (theme: Theme, commonSettings: CommonSettings) => Partial<Theme["typography"]>,
 ) =>
     createTheme(theme, {

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -35,7 +35,7 @@ export const sizesConfig = {
 const commonSettings = {
     dropdownPopperZindex: 2147483647,
     iconDefaultFontSize: 20,
-    inputMinWidth: "200px",
+    inputMinWidth: "75px",
     fonts: {
         roboto: ["roboto", "sans-serif"].join(", "),
         monospace: ["Menlo", "Monaco", "Consolas", "Courier New", "monospace"].join(", "),

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -50,13 +50,13 @@ const commonSettings = {
 export type CommonSettings = typeof commonSettings;
 
 const createCustomTheme = (
-    palette: object,
+    palette: (theme: Theme) => Partial<Theme["palette"]>,
     typography: (theme: Theme, commonSettings: CommonSettings) => Partial<Theme["typography"]>,
 ) => {
     const defaultTheme = createTheme();
     return createTheme(defaultTheme, {
         ...commonSettings,
-        palette,
+        palette: palette(defaultTheme),
         shadows: shadows(defaultTheme),
         components: {
             ...icons(),

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -10,8 +10,25 @@ import shadows from "./shadows";
 import oldTypography, { Typography } from "./typography";
 
 export const sizesConfig = {
-    buttonPrimary: {
+    menuItem: {
         height: "32.5px",
+    },
+    button: {
+        height: {
+            small: "32px",
+            medium: "40px",
+            large: "48px",
+        },
+        startIcon: {
+            small: "18px",
+            medium: "20px",
+            large: "22px",
+        },
+        icon: {
+            small: "24px",
+            medium: "24px",
+            large: "24px",
+        },
     },
 };
 
@@ -27,23 +44,23 @@ const commonSettings = {
         dropdown: {
             s: {
                 width: "64px",
-                height: sizesConfig.buttonPrimary.height,
+                height: sizesConfig.menuItem.height,
             },
             m: {
                 width: "128px",
-                height: sizesConfig.buttonPrimary.height,
+                height: sizesConfig.menuItem.height,
             },
             l: {
                 width: "192px",
-                height: sizesConfig.buttonPrimary.height,
+                height: sizesConfig.menuItem.height,
             },
             xl: {
                 width: "256px",
-                height: sizesConfig.buttonPrimary.height,
+                height: sizesConfig.menuItem.height,
             },
             inherit: {
                 width: "auto",
-                height: sizesConfig.buttonPrimary.height,
+                height: sizesConfig.menuItem.height,
             },
         },
         header: {
@@ -51,9 +68,10 @@ const commonSettings = {
                 height: "30px",
             },
         },
-        input: {
-            defaultLineHeight: "1.3125rem",
-            largeLineHeight: "1.375rem",
+        button: {
+            small: sizesConfig.button.height.small,
+            medium: sizesConfig.button.height.medium,
+            large: sizesConfig.button.height.large,
         },
     },
     breakpoints: {

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -15,21 +15,21 @@ export const sizesConfig = {
     },
     button: {
         small: {
-            height: "32px",
+            height: 8,
             icon: "1.375rem",
             startIcon: "1.125rem",
             paddingX: 2.5,
         },
         medium: {
-            height: "40px",
+            height: 10,
             icon: "1.5rem",
             startIcon: "1.25rem",
             paddingX: 4,
         },
         large: {
-            height: "48px",
+            height: 12,
             icon: "1.625rem",
-            startIcon: "1.375px",
+            startIcon: "1.375rem",
             paddingX: 5.5,
         },
     },

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -7,7 +7,7 @@ import inputs from "./components/inputs";
 import tooltips from "./components/tooltips";
 import { paletteDark, paletteLight } from "./palette";
 import shadows from "./shadows";
-import oldTypography, { Typography } from "./typography";
+import Typography, { MDTypography } from "./typography";
 
 export const sizesConfig = {
     menuItem: {
@@ -135,9 +135,9 @@ const patchTheme = (theme: Theme, typography: any) => {
     });
 };
 
-export const oldLightMaterialUITheme = patchTheme(lightThemePrototype, oldTypography);
-export const LightMaterialUITheme = patchTheme(lightThemePrototype, Typography);
-export const DarkMaterialUITheme = patchTheme(darkThemePrototype, Typography);
+export const oldLightMaterialUITheme = patchTheme(lightThemePrototype, Typography);
+export const LightMaterialUITheme = patchTheme(lightThemePrototype, MDTypography);
+export const DarkMaterialUITheme = patchTheme(darkThemePrototype, MDTypography);
 
 // Temporarily use oldTypography for compatibility purposes with the web app.
 // TODO: make light and dark themes both use Typography and remove "old".

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -49,42 +49,38 @@ const commonSettings = {
 
 export type CommonSettings = typeof commonSettings;
 
-const defaultTheme = createTheme();
-
 const createCustomTheme = (
-    theme: Theme,
     palette: object,
     typography: (theme: Theme, commonSettings: CommonSettings) => Partial<Theme["typography"]>,
-) =>
-    createTheme(theme, {
+) => {
+    const defaultTheme = createTheme();
+    return createTheme(defaultTheme, {
         ...commonSettings,
         palette,
-        shadows: shadows(theme),
+        shadows: shadows(defaultTheme),
         components: {
             ...icons(),
-            ...buttons(theme, commonSettings),
+            ...buttons(defaultTheme, commonSettings),
             ...chips(),
             ...tooltips(),
-            ...inputs(theme, commonSettings),
+            ...inputs(defaultTheme, commonSettings),
             ...cssBaseline(),
         },
-        typography: typography(theme, commonSettings),
+        typography: typography(defaultTheme, commonSettings),
     });
+};
 
 export const oldLightMaterialUITheme = createCustomTheme(
-    defaultTheme,
     { ...paletteLight, mode: "light" },
     typography,
 );
 
 export const LightMaterialUITheme = createCustomTheme(
-    defaultTheme,
     { ...paletteLight, mode: "light" },
     MDTypography,
 );
 
 export const DarkMaterialUITheme = createCustomTheme(
-    defaultTheme,
     { ...paletteDark, mode: "dark" },
     MDTypography,
 );

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -68,11 +68,7 @@ const commonSettings = {
                 height: "30px",
             },
         },
-        button: {
-            small: sizesConfig.button.height.small,
-            medium: sizesConfig.button.height.medium,
-            large: sizesConfig.button.height.large,
-        },
+        button: sizesConfig.button,
     },
     breakpoints: {
         values: {

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -51,6 +51,10 @@ const commonSettings = {
                 height: "30px",
             },
         },
+        input: {
+            defaultLineHeight: "1.3125rem",
+            largeLineHeight: "1.375rem",
+        },
     },
     breakpoints: {
         values: {
@@ -107,10 +111,10 @@ const patchTheme = (theme: Theme, typography: any) => {
         typography: typography(theme),
         shadows: shadows(theme),
         components: {
-            ...buttons(theme),
+            ...buttons(theme, commonSettings),
             ...chips(),
             ...tooltips(),
-            ...inputs(commonSettings),
+            ...inputs(theme, commonSettings),
             ...MuiSvgIconSizesOverrides,
             ...MuiCssBaselineOverrides,
         },

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -16,21 +16,21 @@ export const sizesConfig = {
     button: {
         small: {
             height: "32px",
-            icon: "22px",
-            startIcon: "18px",
-            paddingX: "10px",
+            icon: "1.375rem",
+            startIcon: "1.125rem",
+            paddingX: 2.5,
         },
         medium: {
             height: "40px",
-            icon: "24px",
-            startIcon: "20px",
-            paddingX: "16px",
+            icon: "1.5rem",
+            startIcon: "1.25rem",
+            paddingX: 4,
         },
         large: {
             height: "48px",
-            icon: "26px",
-            startIcon: "22px",
-            paddingX: "22px",
+            icon: "1.625rem",
+            startIcon: "1.375px",
+            paddingX: 5.5,
         },
     },
 };

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -70,20 +70,9 @@ const createCustomTheme = (
     });
 };
 
-export const oldLightMaterialUITheme = createCustomTheme(
-    { ...paletteLight, mode: "light" },
-    typography,
-);
-
-export const LightMaterialUITheme = createCustomTheme(
-    { ...paletteLight, mode: "light" },
-    MDTypography,
-);
-
-export const DarkMaterialUITheme = createCustomTheme(
-    { ...paletteDark, mode: "dark" },
-    MDTypography,
-);
+export const oldLightMaterialUITheme = createCustomTheme(paletteLight, typography);
+export const LightMaterialUITheme = createCustomTheme(paletteDark, MDTypography);
+export const DarkMaterialUITheme = createCustomTheme(paletteDark, MDTypography);
 
 // Temporarily use oldTypography for compatibility purposes with the web app.
 // TODO: make light and dark themes both use Typography and remove "old".

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -30,7 +30,7 @@ const commonSettings = {
             },
             large: {
                 height: 6,
-                icon: "1.625rem",
+                icon: "1.5rem",
                 startIcon: "1.375rem",
                 paddingX: 2.75,
             },

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -17,22 +17,22 @@ const commonSettings = {
         button: {
             // numbers are in theme.spacing units
             small: {
-                height: 8,
+                height: 4,
                 icon: "1.375rem",
                 startIcon: "1.125rem",
-                paddingX: 2.5,
+                paddingX: 1.25,
             },
             medium: {
-                height: 10,
+                height: 5,
                 icon: "1.5rem",
                 startIcon: "1.25rem",
-                paddingX: 4,
+                paddingX: 2,
             },
             large: {
-                height: 12,
+                height: 6,
                 icon: "1.625rem",
                 startIcon: "1.375rem",
-                paddingX: 5.5,
+                paddingX: 2.75,
             },
         },
     },

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -14,20 +14,23 @@ export const sizesConfig = {
         height: "32.5px",
     },
     button: {
-        height: {
-            small: "32px",
-            medium: "40px",
-            large: "48px",
+        small: {
+            height: "32px",
+            icon: "22px",
+            startIcon: "18px",
+            paddingX: "10px",
         },
-        startIcon: {
-            small: "18px",
-            medium: "20px",
-            large: "22px",
+        medium: {
+            height: "40px",
+            icon: "24px",
+            startIcon: "20px",
+            paddingX: "16px",
         },
-        icon: {
-            small: "24px",
-            medium: "24px",
-            large: "24px",
+        large: {
+            height: "48px",
+            icon: "26px",
+            startIcon: "22px",
+            paddingX: "22px",
         },
     },
 };

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,77 +1,40 @@
-import darkScrollbar from "@mui/material/darkScrollbar";
 import { createTheme, Theme } from "@mui/material/styles";
 
-import buttons from "./components/buttons";
-import chips from "./components/chips";
-import inputs from "./components/inputs";
-import tooltips from "./components/tooltips";
+import { buttons, chips, cssBaseline, icons, inputs, tooltips } from "./components";
 import { paletteDark, paletteLight } from "./palette";
 import shadows from "./shadows";
-import Typography, { MDTypography } from "./typography";
-
-export const sizesConfig = {
-    menuItem: {
-        height: "32.5px",
-    },
-    button: {
-        small: {
-            height: 8,
-            icon: "1.375rem",
-            startIcon: "1.125rem",
-            paddingX: 2.5,
-        },
-        medium: {
-            height: 10,
-            icon: "1.5rem",
-            startIcon: "1.25rem",
-            paddingX: 4,
-        },
-        large: {
-            height: 12,
-            icon: "1.625rem",
-            startIcon: "1.375rem",
-            paddingX: 5.5,
-        },
-    },
-};
+import { MDTypography, typography } from "./typography";
 
 const commonSettings = {
     dropdownPopperZindex: 2147483647,
     iconDefaultFontSize: 20,
     inputMinWidth: "75px",
     fonts: {
-        roboto: ["roboto", "sans-serif"].join(", "),
+        roboto: ["Roboto", "-apple-system", "sans-serif"].join(","),
         monospace: ["Menlo", "Monaco", "Consolas", "Courier New", "monospace"].join(", "),
     },
     sizes: {
-        dropdown: {
-            s: {
-                width: "64px",
-                height: sizesConfig.menuItem.height,
+        button: {
+            // numbers are in theme.spacing units
+            small: {
+                height: 8,
+                icon: "1.375rem",
+                startIcon: "1.125rem",
+                paddingX: 2.5,
             },
-            m: {
-                width: "128px",
-                height: sizesConfig.menuItem.height,
+            medium: {
+                height: 10,
+                icon: "1.5rem",
+                startIcon: "1.25rem",
+                paddingX: 4,
             },
-            l: {
-                width: "192px",
-                height: sizesConfig.menuItem.height,
-            },
-            xl: {
-                width: "256px",
-                height: sizesConfig.menuItem.height,
-            },
-            inherit: {
-                width: "auto",
-                height: sizesConfig.menuItem.height,
-            },
-        },
-        header: {
-            subHeader: {
-                height: "30px",
+            large: {
+                height: 12,
+                icon: "1.625rem",
+                startIcon: "1.375rem",
+                paddingX: 5.5,
             },
         },
-        button: sizesConfig.button,
     },
     breakpoints: {
         values: {
@@ -84,63 +47,47 @@ const commonSettings = {
     },
 };
 
-const MuiSvgIconSizesOverrides = {
-    MuiSvgIcon: {
-        variants: [
-            {
-                props: { fontSize: "small" },
-                style: {
-                    fontSize: "18px",
-                },
-            },
-            {
-                props: { fontSize: "medium" },
-                style: {
-                    fontSize: "20px",
-                },
-            },
-            {
-                props: { fontSize: "large" },
-                style: {
-                    fontSize: "35px",
-                },
-            },
-        ],
-    },
-};
-// Used to make scrollbars dark in dark mode per https://mui.com/material-ui/react-css-baseline/#scrollbars
-// Otherwise, b/c the Dialogs are appended to the body, they will have light scrollbars in dark mode
-const MuiCssBaselineOverrides = {
-    MuiCssBaseline: {
-        styleOverrides: (themeParam: Theme) => ({
-            body: themeParam.palette.mode === "dark" ? darkScrollbar() : null,
-        }),
-    },
-};
+export type CommonSettings = typeof commonSettings;
 
-const lightThemePrototype = createTheme({ palette: { ...paletteLight, mode: "light" } });
-const darkThemePrototype = createTheme({ palette: { ...paletteDark, mode: "dark" } });
+const defaultTheme = createTheme();
 
-// TODO: figure out how to avoid having to patch the theme and use the above createTheme() function instead
-const patchTheme = (theme: Theme, typography: any) => {
-    return createTheme(theme, {
+const createCustomTheme = (
+    theme: Theme,
+    palette: Partial<Theme["palette"]>,
+    typography: (theme: Theme, commonSettings: CommonSettings) => Partial<Theme["typography"]>,
+) =>
+    createTheme(theme, {
         ...commonSettings,
-        typography: typography(theme),
+        palette,
         shadows: shadows(theme),
         components: {
+            ...icons(),
             ...buttons(theme, commonSettings),
             ...chips(),
             ...tooltips(),
             ...inputs(theme, commonSettings),
-            ...MuiSvgIconSizesOverrides,
-            ...MuiCssBaselineOverrides,
+            ...cssBaseline(),
         },
+        typography: typography(theme, commonSettings),
     });
-};
 
-export const oldLightMaterialUITheme = patchTheme(lightThemePrototype, Typography);
-export const LightMaterialUITheme = patchTheme(lightThemePrototype, MDTypography);
-export const DarkMaterialUITheme = patchTheme(darkThemePrototype, MDTypography);
+export const oldLightMaterialUITheme = createCustomTheme(
+    defaultTheme,
+    { ...paletteLight, mode: "light" },
+    typography,
+);
+
+export const LightMaterialUITheme = createCustomTheme(
+    defaultTheme,
+    { ...paletteLight, mode: "light" },
+    MDTypography,
+);
+
+export const DarkMaterialUITheme = createCustomTheme(
+    defaultTheme,
+    { ...paletteDark, mode: "dark" },
+    MDTypography,
+);
 
 // Temporarily use oldTypography for compatibility purposes with the web app.
 // TODO: make light and dark themes both use Typography and remove "old".

--- a/src/theme/themeTest/TestComponentContainer.tsx
+++ b/src/theme/themeTest/TestComponentContainer.tsx
@@ -1,0 +1,23 @@
+import Paper from "@mui/material/Paper";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import React from "react";
+
+function TestComponentContainer({
+    title,
+    children,
+}: {
+    title?: React.ReactNode;
+    children?: React.ReactNode;
+}) {
+    return (
+        <Paper sx={{ p: 2, m: 2 }} elevation={1}>
+            <Stack spacing={2} alignItems="center">
+                {title && <Typography variant="h6">{title}</Typography>}
+                {children}
+            </Stack>
+        </Paper>
+    );
+}
+
+export default TestComponentContainer;

--- a/src/theme/themeTest/ThemeTest.tsx
+++ b/src/theme/themeTest/ThemeTest.tsx
@@ -2,7 +2,7 @@ import { createTheme, ThemeProvider } from "@mui/material";
 import Box from "@mui/material/Box";
 import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
-import { useTheme } from "@mui/material/styles";
+import { Theme, useTheme } from "@mui/material/styles";
 import React from "react";
 
 import { ButtonTest } from "./buttons/Button";
@@ -15,8 +15,8 @@ import { SelectTest } from "./inputs/Select";
 import { TextFieldTest } from "./inputs/TextField";
 import { TypographyTest } from "./typography/Typography";
 
-export default function ThemeTest() {
-    const theme = useTheme();
+export default function ThemeTest({ theme }: { theme: Theme }) {
+    theme = theme || useTheme();
     const extendedTheme = createTheme(theme, {});
 
     const testComponents = [

--- a/src/theme/themeTest/ThemeTest.tsx
+++ b/src/theme/themeTest/ThemeTest.tsx
@@ -16,23 +16,19 @@ import { TextFieldTest } from "./inputs/TextField";
 import { TypographyTest } from "./typography/Typography";
 
 export default function ThemeTest({ theme = oldLightMaterialUITheme }: { theme?: Theme }) {
-    const testComponents = [
-        <ButtonTest />,
-        <IconButtonTest />,
-        <ButtonGroupTest />,
-        <ToggleButtonTest />,
-        <SwitchTest />,
-        <TextFieldTest />,
-        <AutocompleteTest />,
-        <SelectTest />,
-        <TypographyTest />,
-    ];
-
     return (
         <ThemeProvider theme={theme}>
             <Box>
                 <Stack spacing={2} m={2}>
-                    {testComponents}
+                    <ButtonTest />
+                    <IconButtonTest />
+                    <ButtonGroupTest />
+                    <ToggleButtonTest />
+                    <SwitchTest />
+                    <TextFieldTest />
+                    <AutocompleteTest />
+                    <SelectTest />
+                    <TypographyTest />
                 </Stack>
             </Box>
         </ThemeProvider>

--- a/src/theme/themeTest/ThemeTest.tsx
+++ b/src/theme/themeTest/ThemeTest.tsx
@@ -17,7 +17,6 @@ import { TypographyTest } from "./typography/Typography";
 
 export default function ThemeTest({ theme }: { theme: Theme }) {
     theme = theme || useTheme();
-    const extendedTheme = createTheme(theme, {});
 
     const testComponents = [
         ButtonTest,
@@ -32,7 +31,7 @@ export default function ThemeTest({ theme }: { theme: Theme }) {
     ];
 
     return (
-        <ThemeProvider theme={extendedTheme}>
+        <ThemeProvider theme={theme}>
             <Box>
                 <Stack spacing={2} m={2}>
                     {testComponents.map((Component) => (

--- a/src/theme/themeTest/ThemeTest.tsx
+++ b/src/theme/themeTest/ThemeTest.tsx
@@ -1,0 +1,47 @@
+import { createTheme, ThemeProvider } from "@mui/material";
+import Box from "@mui/material/Box";
+import Paper from "@mui/material/Paper";
+import Stack from "@mui/material/Stack";
+import { useTheme } from "@mui/material/styles";
+import React from "react";
+
+import { ButtonTest } from "./buttons/Button";
+import { ButtonGroupTest } from "./buttons/ButtonGroup";
+import { IconButtonTest } from "./buttons/IconButton";
+import { SwitchTest } from "./buttons/Switch";
+import { ToggleButtonTest } from "./buttons/ToggleButton";
+import { AutocompleteTest } from "./inputs/Autocomplete";
+import { SelectTest } from "./inputs/Select";
+import { TextFieldTest } from "./inputs/TextField";
+import { TypographyTest } from "./typography/Typography";
+
+export default function ThemeTest() {
+    const theme = useTheme();
+    const extendedTheme = createTheme(theme, {});
+
+    const testComponents = [
+        ButtonTest,
+        IconButtonTest,
+        ButtonGroupTest,
+        ToggleButtonTest,
+        SwitchTest,
+        TextFieldTest,
+        AutocompleteTest,
+        SelectTest,
+        TypographyTest,
+    ];
+
+    return (
+        <ThemeProvider theme={extendedTheme}>
+            <Box>
+                <Stack spacing={2} m={2}>
+                    {testComponents.map((Component) => (
+                        <Paper sx={{ p: 2, m: 2 }} elevation={1}>
+                            <Component />
+                        </Paper>
+                    ))}
+                </Stack>
+            </Box>
+        </ThemeProvider>
+    );
+}

--- a/src/theme/themeTest/ThemeTest.tsx
+++ b/src/theme/themeTest/ThemeTest.tsx
@@ -16,29 +16,23 @@ import { TextFieldTest } from "./inputs/TextField";
 import { TypographyTest } from "./typography/Typography";
 
 export default function ThemeTest({ theme }: { theme: Theme }) {
-    theme = theme || useTheme();
-
     const testComponents = [
-        ButtonTest,
-        IconButtonTest,
-        ButtonGroupTest,
-        ToggleButtonTest,
-        SwitchTest,
-        TextFieldTest,
-        AutocompleteTest,
-        SelectTest,
-        TypographyTest,
+        <ButtonTest />,
+        <IconButtonTest />,
+        <ButtonGroupTest />,
+        <ToggleButtonTest />,
+        <SwitchTest />,
+        <TextFieldTest />,
+        <AutocompleteTest />,
+        <SelectTest />,
+        <TypographyTest />,
     ];
 
     return (
         <ThemeProvider theme={theme}>
             <Box>
                 <Stack spacing={2} m={2}>
-                    {testComponents.map((Component) => (
-                        <Paper sx={{ p: 2, m: 2 }} elevation={1}>
-                            <Component />
-                        </Paper>
-                    ))}
+                    {testComponents}
                 </Stack>
             </Box>
         </ThemeProvider>

--- a/src/theme/themeTest/ThemeTest.tsx
+++ b/src/theme/themeTest/ThemeTest.tsx
@@ -1,10 +1,10 @@
-import { createTheme, ThemeProvider } from "@mui/material";
+import { ThemeProvider } from "@mui/material";
 import Box from "@mui/material/Box";
-import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
-import { Theme, useTheme } from "@mui/material/styles";
+import { Theme } from "@mui/material/styles";
 import React from "react";
 
+import { oldLightMaterialUITheme } from "../theme";
 import { ButtonTest } from "./buttons/Button";
 import { ButtonGroupTest } from "./buttons/ButtonGroup";
 import { IconButtonTest } from "./buttons/IconButton";
@@ -15,7 +15,7 @@ import { SelectTest } from "./inputs/Select";
 import { TextFieldTest } from "./inputs/TextField";
 import { TypographyTest } from "./typography/Typography";
 
-export default function ThemeTest({ theme }: { theme: Theme }) {
+export default function ThemeTest({ theme = oldLightMaterialUITheme }: { theme?: Theme }) {
     const testComponents = [
         <ButtonTest />,
         <IconButtonTest />,

--- a/src/theme/themeTest/buttons/Button.tsx
+++ b/src/theme/themeTest/buttons/Button.tsx
@@ -1,0 +1,47 @@
+import Save from "@mui/icons-material/Save";
+import Button from "@mui/material/Button";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import React from "react";
+
+function BasicButtonVariants({
+    size = "medium",
+    variant = "contained",
+}: {
+    size: "small" | "medium" | "large";
+    variant: "text" | "outlined" | "contained";
+}) {
+    return (
+        <Stack direction="row" spacing={2}>
+            <Button variant={variant} size={size}>
+                Primary
+            </Button>
+            <Button variant={variant} size={size} disabled>
+                Disabled
+            </Button>
+            <Button variant={variant} size={size} startIcon={<Save />}>
+                start icon
+            </Button>
+            <Button variant={variant} size={size}>
+                <Save fontSize="inherit" />
+            </Button>
+        </Stack>
+    );
+}
+
+export function ButtonTest() {
+    return (
+        <Stack spacing={2} alignItems="center">
+            <Typography variant="h6">Button</Typography>
+            <BasicButtonVariants size="small" variant="contained" />
+            <BasicButtonVariants size="small" variant="outlined" />
+            <BasicButtonVariants size="small" variant="text" />
+            <BasicButtonVariants size="medium" variant="contained" />
+            <BasicButtonVariants size="medium" variant="outlined" />
+            <BasicButtonVariants size="medium" variant="text" />
+            <BasicButtonVariants size="large" variant="contained" />
+            <BasicButtonVariants size="large" variant="outlined" />
+            <BasicButtonVariants size="large" variant="text" />
+        </Stack>
+    );
+}

--- a/src/theme/themeTest/buttons/Button.tsx
+++ b/src/theme/themeTest/buttons/Button.tsx
@@ -1,47 +1,38 @@
 import Save from "@mui/icons-material/Save";
-import Button from "@mui/material/Button";
+import Button, { ButtonProps } from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import React from "react";
 
-function BasicButtonVariants({
-    size = "medium",
-    variant = "contained",
-}: {
-    size: "small" | "medium" | "large";
-    variant: "text" | "outlined" | "contained";
-}) {
-    return (
-        <Stack direction="row" spacing={2}>
-            <Button variant={variant} size={size}>
-                Primary
-            </Button>
-            <Button variant={variant} size={size} disabled>
-                Disabled
-            </Button>
-            <Button variant={variant} size={size} startIcon={<Save />}>
-                start icon
-            </Button>
-            <Button variant={variant} size={size}>
-                <Save fontSize="inherit" />
-            </Button>
-        </Stack>
-    );
-}
+import TestComponentContainer from "../TestComponentContainer";
 
 export function ButtonTest() {
+    const sizes: ButtonProps["size"][] = ["small", "medium", "large"];
+    const variants: ButtonProps["variant"][] = ["contained", "outlined", "text"];
     return (
-        <Stack spacing={2} alignItems="center">
-            <Typography variant="h6">Button</Typography>
-            <BasicButtonVariants size="small" variant="contained" />
-            <BasicButtonVariants size="small" variant="outlined" />
-            <BasicButtonVariants size="small" variant="text" />
-            <BasicButtonVariants size="medium" variant="contained" />
-            <BasicButtonVariants size="medium" variant="outlined" />
-            <BasicButtonVariants size="medium" variant="text" />
-            <BasicButtonVariants size="large" variant="contained" />
-            <BasicButtonVariants size="large" variant="outlined" />
-            <BasicButtonVariants size="large" variant="text" />
-        </Stack>
+        <TestComponentContainer title="Button">
+            {sizes.map((size) => (
+                <>
+                    <Typography variant="body2">{size}</Typography>
+                    {variants.map((variant) => (
+                        <Stack direction="row" spacing={2}>
+                            <Typography variant="caption">{variant}</Typography>
+                            <Button variant={variant} size={size}>
+                                Primary
+                            </Button>
+                            <Button variant={variant} size={size} disabled>
+                                Disabled
+                            </Button>
+                            <Button variant={variant} size={size} startIcon={<Save />}>
+                                start icon
+                            </Button>
+                            <Button variant={variant} size={size}>
+                                <Save fontSize="inherit" />
+                            </Button>
+                        </Stack>
+                    ))}
+                </>
+            ))}
+        </TestComponentContainer>
     );
 }

--- a/src/theme/themeTest/buttons/Button.tsx
+++ b/src/theme/themeTest/buttons/Button.tsx
@@ -15,7 +15,7 @@ export function ButtonTest() {
                 <>
                     <Typography variant="body2">{size}</Typography>
                     {variants.map((variant) => (
-                        <Stack direction="row" spacing={2}>
+                        <Stack direction="row" spacing={2} key={variant}>
                             <Typography variant="caption">{variant}</Typography>
                             <Button variant={variant} size={size}>
                                 Primary

--- a/src/theme/themeTest/buttons/Button.tsx
+++ b/src/theme/themeTest/buttons/Button.tsx
@@ -15,7 +15,7 @@ export function ButtonTest() {
                 <>
                     <Typography variant="body2">{size}</Typography>
                     {variants.map((variant) => (
-                        <Stack direction="row" spacing={2} key={variant}>
+                        <Stack direction="row" spacing={2} alignItems="center" key={variant}>
                             <Typography variant="caption">{variant}</Typography>
                             <Button variant={variant} size={size}>
                                 Primary

--- a/src/theme/themeTest/buttons/Button.tsx
+++ b/src/theme/themeTest/buttons/Button.tsx
@@ -12,7 +12,7 @@ export function ButtonTest() {
     return (
         <TestComponentContainer title="Button">
             {sizes.map((size) => (
-                <>
+                <React.Fragment key={size}>
                     <Typography variant="body2">{size}</Typography>
                     {variants.map((variant) => (
                         <Stack direction="row" spacing={2} alignItems="center" key={variant}>
@@ -31,7 +31,7 @@ export function ButtonTest() {
                             </Button>
                         </Stack>
                     ))}
-                </>
+                </React.Fragment>
             ))}
         </TestComponentContainer>
     );

--- a/src/theme/themeTest/buttons/ButtonGroup.tsx
+++ b/src/theme/themeTest/buttons/ButtonGroup.tsx
@@ -18,7 +18,7 @@ export function ButtonGroupTest() {
                 <>
                     <Typography variant="body2">{size}</Typography>
                     {variants.map((variant) => (
-                        <Stack direction="row" spacing={2}>
+                        <Stack direction="row" spacing={2} key={variant}>
                             <Typography variant="caption">{variant}</Typography>
                             <ButtonGroup variant={variant} size={size}>
                                 <Button>One</Button>

--- a/src/theme/themeTest/buttons/ButtonGroup.tsx
+++ b/src/theme/themeTest/buttons/ButtonGroup.tsx
@@ -15,7 +15,7 @@ export function ButtonGroupTest() {
     return (
         <TestComponentContainer title="Button Group">
             {sizes.map((size) => (
-                <>
+                <React.Fragment key={size}>
                     <Typography variant="body2">{size}</Typography>
                     {variants.map((variant) => (
                         <Stack direction="row" spacing={2} alignItems="center" key={variant}>
@@ -38,7 +38,7 @@ export function ButtonGroupTest() {
                             </ButtonGroup>
                         </Stack>
                     ))}
-                </>
+                </React.Fragment>
             ))}
         </TestComponentContainer>
     );

--- a/src/theme/themeTest/buttons/ButtonGroup.tsx
+++ b/src/theme/themeTest/buttons/ButtonGroup.tsx
@@ -1,43 +1,45 @@
+import Looks from "@mui/icons-material/Looks";
+import Looks3 from "@mui/icons-material/Looks3";
 import LooksTwo from "@mui/icons-material/LooksTwo";
 import Button from "@mui/material/Button";
-import ButtonGroup from "@mui/material/ButtonGroup";
+import ButtonGroup, { ButtonGroupProps } from "@mui/material/ButtonGroup";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import React from "react";
 
-function ButtonGroupVariants({
-    size = "medium",
-    variant = "contained",
-}: {
-    size: "small" | "medium" | "large";
-    variant: "text" | "outlined" | "contained";
-}) {
-    return (
-        <Stack direction="row" spacing={2}>
-            <ButtonGroup variant={variant} size={size}>
-                <Button>One</Button>
-                <Button>
-                    <LooksTwo />
-                </Button>
-                <Button>Three</Button>
-            </ButtonGroup>
-        </Stack>
-    );
-}
+import TestComponentContainer from "../TestComponentContainer";
 
 export function ButtonGroupTest() {
+    const sizes: ButtonGroupProps["size"][] = ["small", "medium", "large"];
+    const variants: ButtonGroupProps["variant"][] = ["contained", "outlined", "text"];
     return (
-        <Stack spacing={2} alignItems="center">
-            <Typography variant="h6">Button Group</Typography>
-            <ButtonGroupVariants size="small" variant="contained" />
-            <ButtonGroupVariants size="small" variant="outlined" />
-            <ButtonGroupVariants size="small" variant="text" />
-            <ButtonGroupVariants size="medium" variant="contained" />
-            <ButtonGroupVariants size="medium" variant="outlined" />
-            <ButtonGroupVariants size="medium" variant="text" />
-            <ButtonGroupVariants size="large" variant="contained" />
-            <ButtonGroupVariants size="large" variant="outlined" />
-            <ButtonGroupVariants size="large" variant="text" />
-        </Stack>
+        <TestComponentContainer title="Button Group">
+            {sizes.map((size) => (
+                <>
+                    <Typography variant="body2">{size}</Typography>
+                    {variants.map((variant) => (
+                        <Stack direction="row" spacing={2}>
+                            <Typography variant="caption">{variant}</Typography>
+                            <ButtonGroup variant={variant} size={size}>
+                                <Button>One</Button>
+                                <Button>Two</Button>
+                                <Button>Three</Button>
+                            </ButtonGroup>
+                            <ButtonGroup variant={variant} size={size}>
+                                <Button>
+                                    <Looks />
+                                </Button>
+                                <Button>
+                                    <LooksTwo />
+                                </Button>
+                                <Button>
+                                    <Looks3 />
+                                </Button>
+                            </ButtonGroup>
+                        </Stack>
+                    ))}
+                </>
+            ))}
+        </TestComponentContainer>
     );
 }

--- a/src/theme/themeTest/buttons/ButtonGroup.tsx
+++ b/src/theme/themeTest/buttons/ButtonGroup.tsx
@@ -1,5 +1,5 @@
-import Looks from "@mui/icons-material/Looks";
 import Looks3 from "@mui/icons-material/Looks3";
+import LooksOne from "@mui/icons-material/LooksOne";
 import LooksTwo from "@mui/icons-material/LooksTwo";
 import Button from "@mui/material/Button";
 import ButtonGroup, { ButtonGroupProps } from "@mui/material/ButtonGroup";
@@ -27,7 +27,7 @@ export function ButtonGroupTest() {
                             </ButtonGroup>
                             <ButtonGroup variant={variant} size={size}>
                                 <Button>
-                                    <Looks />
+                                    <LooksOne />
                                 </Button>
                                 <Button>
                                     <LooksTwo />

--- a/src/theme/themeTest/buttons/ButtonGroup.tsx
+++ b/src/theme/themeTest/buttons/ButtonGroup.tsx
@@ -1,0 +1,43 @@
+import LooksTwo from "@mui/icons-material/LooksTwo";
+import Button from "@mui/material/Button";
+import ButtonGroup from "@mui/material/ButtonGroup";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import React from "react";
+
+function ButtonGroupVariants({
+    size = "medium",
+    variant = "contained",
+}: {
+    size: "small" | "medium" | "large";
+    variant: "text" | "outlined" | "contained";
+}) {
+    return (
+        <Stack direction="row" spacing={2}>
+            <ButtonGroup variant={variant} size={size}>
+                <Button>One</Button>
+                <Button>
+                    <LooksTwo />
+                </Button>
+                <Button>Three</Button>
+            </ButtonGroup>
+        </Stack>
+    );
+}
+
+export function ButtonGroupTest() {
+    return (
+        <Stack spacing={2} alignItems="center">
+            <Typography variant="h6">Button Group</Typography>
+            <ButtonGroupVariants size="small" variant="contained" />
+            <ButtonGroupVariants size="small" variant="outlined" />
+            <ButtonGroupVariants size="small" variant="text" />
+            <ButtonGroupVariants size="medium" variant="contained" />
+            <ButtonGroupVariants size="medium" variant="outlined" />
+            <ButtonGroupVariants size="medium" variant="text" />
+            <ButtonGroupVariants size="large" variant="contained" />
+            <ButtonGroupVariants size="large" variant="outlined" />
+            <ButtonGroupVariants size="large" variant="text" />
+        </Stack>
+    );
+}

--- a/src/theme/themeTest/buttons/ButtonGroup.tsx
+++ b/src/theme/themeTest/buttons/ButtonGroup.tsx
@@ -18,7 +18,7 @@ export function ButtonGroupTest() {
                 <>
                     <Typography variant="body2">{size}</Typography>
                     {variants.map((variant) => (
-                        <Stack direction="row" spacing={2} key={variant}>
+                        <Stack direction="row" spacing={2} alignItems="center" key={variant}>
                             <Typography variant="caption">{variant}</Typography>
                             <ButtonGroup variant={variant} size={size}>
                                 <Button>One</Button>

--- a/src/theme/themeTest/buttons/IconButton.tsx
+++ b/src/theme/themeTest/buttons/IconButton.tsx
@@ -1,0 +1,32 @@
+import Save from "@mui/icons-material/Save";
+import IconButton from "@mui/material/IconButton";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import * as React from "react";
+
+function IconButtonVariants({ size = "medium" }: { size: "small" | "medium" | "large" }) {
+    return (
+        <Stack direction="row" spacing={2}>
+            <IconButton size={size}>
+                <Save fontSize="inherit" />
+            </IconButton>
+            <IconButton size={size} color="primary">
+                <Save fontSize="inherit" />
+            </IconButton>
+            <IconButton size={size} color="primary" disabled>
+                <Save fontSize="inherit" />
+            </IconButton>
+        </Stack>
+    );
+}
+
+export function IconButtonTest() {
+    return (
+        <Stack spacing={2} alignItems="center">
+            <Typography variant="h6">Icon Button</Typography>
+            <IconButtonVariants size="small" />
+            <IconButtonVariants size="medium" />
+            <IconButtonVariants size="large" />
+        </Stack>
+    );
+}

--- a/src/theme/themeTest/buttons/IconButton.tsx
+++ b/src/theme/themeTest/buttons/IconButton.tsx
@@ -11,7 +11,7 @@ export function IconButtonTest() {
     return (
         <TestComponentContainer title="Icon Button">
             {sizes.map((size) => (
-                <Stack direction="row" spacing={2}>
+                <Stack direction="row" spacing={2} key={size}>
                     <Typography variant="caption">{size}</Typography>
                     <IconButton size={size}>
                         <Save />

--- a/src/theme/themeTest/buttons/IconButton.tsx
+++ b/src/theme/themeTest/buttons/IconButton.tsx
@@ -1,32 +1,29 @@
 import Save from "@mui/icons-material/Save";
-import IconButton from "@mui/material/IconButton";
+import IconButton, { IconButtonProps } from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
-import * as React from "react";
+import React from "react";
 
-function IconButtonVariants({ size = "medium" }: { size: "small" | "medium" | "large" }) {
-    return (
-        <Stack direction="row" spacing={2}>
-            <IconButton size={size}>
-                <Save fontSize="inherit" />
-            </IconButton>
-            <IconButton size={size} color="primary">
-                <Save fontSize="inherit" />
-            </IconButton>
-            <IconButton size={size} color="primary" disabled>
-                <Save fontSize="inherit" />
-            </IconButton>
-        </Stack>
-    );
-}
+import TestComponentContainer from "../TestComponentContainer";
 
 export function IconButtonTest() {
+    const sizes: IconButtonProps["size"][] = ["small", "medium", "large"];
     return (
-        <Stack spacing={2} alignItems="center">
-            <Typography variant="h6">Icon Button</Typography>
-            <IconButtonVariants size="small" />
-            <IconButtonVariants size="medium" />
-            <IconButtonVariants size="large" />
-        </Stack>
+        <TestComponentContainer title="Icon Button">
+            {sizes.map((size) => (
+                <Stack direction="row" spacing={2}>
+                    <Typography variant="caption">{size}</Typography>
+                    <IconButton size={size}>
+                        <Save />
+                    </IconButton>
+                    <IconButton size={size} color="primary">
+                        <Save />
+                    </IconButton>
+                    <IconButton size={size} color="primary" disabled>
+                        <Save />
+                    </IconButton>
+                </Stack>
+            ))}
+        </TestComponentContainer>
     );
 }

--- a/src/theme/themeTest/buttons/IconButton.tsx
+++ b/src/theme/themeTest/buttons/IconButton.tsx
@@ -11,7 +11,7 @@ export function IconButtonTest() {
     return (
         <TestComponentContainer title="Icon Button">
             {sizes.map((size) => (
-                <Stack direction="row" spacing={2} key={size}>
+                <Stack direction="row" spacing={2} alignItems="center" key={size}>
                     <Typography variant="caption">{size}</Typography>
                     <IconButton size={size}>
                         <Save />

--- a/src/theme/themeTest/buttons/Switch.tsx
+++ b/src/theme/themeTest/buttons/Switch.tsx
@@ -11,7 +11,7 @@ export function SwitchTest() {
     return (
         <TestComponentContainer title="Switch">
             {sizes.map((size) => (
-                <Stack direction="row" spacing={1} key="size">
+                <Stack direction="row" spacing={1} key={size}>
                     <Typography variant="caption">{size}</Typography>
                     <Switch defaultChecked size={size} />
                     <Switch defaultChecked size={size} disabled />

--- a/src/theme/themeTest/buttons/Switch.tsx
+++ b/src/theme/themeTest/buttons/Switch.tsx
@@ -16,7 +16,7 @@ export function SwitchTest() {
                     <Switch defaultChecked size={size} />
                     <Switch defaultChecked size={size} disabled />
                     {otherColors.map((color) => (
-                        <Switch defaultChecked color={color} size={size} />
+                        <Switch defaultChecked color={color} size={size} key={color} />
                     ))}
                 </Stack>
             ))}

--- a/src/theme/themeTest/buttons/Switch.tsx
+++ b/src/theme/themeTest/buttons/Switch.tsx
@@ -11,7 +11,7 @@ export function SwitchTest() {
     return (
         <TestComponentContainer title="Switch">
             {sizes.map((size) => (
-                <Stack direction="row" spacing={1} key={size}>
+                <Stack direction="row" spacing={1} alignItems="center" key={size}>
                     <Typography variant="caption">{size}</Typography>
                     <Switch defaultChecked size={size} />
                     <Switch defaultChecked size={size} disabled />

--- a/src/theme/themeTest/buttons/Switch.tsx
+++ b/src/theme/themeTest/buttons/Switch.tsx
@@ -1,0 +1,26 @@
+import Stack from "@mui/material/Stack";
+import Switch from "@mui/material/Switch";
+import Typography from "@mui/material/Typography";
+import React from "react";
+
+export function SwitchTest() {
+    return (
+        <Stack spacing={2} alignItems="center">
+            <Typography variant="h6">Switch</Typography>
+            <Stack direction="row" spacing={1}>
+                <Switch defaultChecked size="small" />
+                <Switch defaultChecked size="small" disabled />
+                <Switch defaultChecked color="secondary" size="small" />
+                <Switch defaultChecked color="warning" size="small" />
+                <Switch defaultChecked color="default" size="small" />
+            </Stack>
+            <Stack direction="row" spacing={1}>
+                <Switch defaultChecked />
+                <Switch defaultChecked disabled />
+                <Switch defaultChecked color="secondary" />
+                <Switch defaultChecked color="warning" />
+                <Switch defaultChecked color="default" />
+            </Stack>
+        </Stack>
+    );
+}

--- a/src/theme/themeTest/buttons/Switch.tsx
+++ b/src/theme/themeTest/buttons/Switch.tsx
@@ -1,26 +1,25 @@
 import Stack from "@mui/material/Stack";
-import Switch from "@mui/material/Switch";
+import Switch, { SwitchProps } from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
 import React from "react";
 
+import TestComponentContainer from "../TestComponentContainer";
+
 export function SwitchTest() {
+    const sizes: SwitchProps["size"][] = ["small", "medium"];
+    const otherColors: SwitchProps["color"][] = ["secondary", "warning", "default"];
     return (
-        <Stack spacing={2} alignItems="center">
-            <Typography variant="h6">Switch</Typography>
-            <Stack direction="row" spacing={1}>
-                <Switch defaultChecked size="small" />
-                <Switch defaultChecked size="small" disabled />
-                <Switch defaultChecked color="secondary" size="small" />
-                <Switch defaultChecked color="warning" size="small" />
-                <Switch defaultChecked color="default" size="small" />
-            </Stack>
-            <Stack direction="row" spacing={1}>
-                <Switch defaultChecked />
-                <Switch defaultChecked disabled />
-                <Switch defaultChecked color="secondary" />
-                <Switch defaultChecked color="warning" />
-                <Switch defaultChecked color="default" />
-            </Stack>
-        </Stack>
+        <TestComponentContainer title="Switch">
+            {sizes.map((size) => (
+                <Stack direction="row" spacing={1} key="size">
+                    <Typography variant="caption">{size}</Typography>
+                    <Switch defaultChecked size={size} />
+                    <Switch defaultChecked size={size} disabled />
+                    {otherColors.map((color) => (
+                        <Switch defaultChecked color={color} size={size} />
+                    ))}
+                </Stack>
+            ))}
+        </TestComponentContainer>
     );
 }

--- a/src/theme/themeTest/buttons/ToggleButton.tsx
+++ b/src/theme/themeTest/buttons/ToggleButton.tsx
@@ -2,12 +2,13 @@ import FormatAlignCenterIcon from "@mui/icons-material/FormatAlignCenter";
 import FormatAlignJustifyIcon from "@mui/icons-material/FormatAlignJustify";
 import FormatAlignLeftIcon from "@mui/icons-material/FormatAlignLeft";
 import FormatAlignRightIcon from "@mui/icons-material/FormatAlignRight";
-import { ButtonProps } from "@mui/material";
 import Stack from "@mui/material/Stack";
 import ToggleButton from "@mui/material/ToggleButton";
-import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import ToggleButtonGroup, { ToggleButtonGroupProps } from "@mui/material/ToggleButtonGroup";
 import Typography from "@mui/material/Typography";
-import * as React from "react";
+import React from "react";
+
+import TestComponentContainer from "../TestComponentContainer";
 
 export function ToggleButtonTest() {
     const [alignment, setAlignment] = React.useState("left");
@@ -16,74 +17,57 @@ export function ToggleButtonTest() {
         setAlignment(newAlignment);
     };
 
-    const childrenIcon = [
-        <ToggleButton value="left" key="left">
-            <FormatAlignLeftIcon />
-        </ToggleButton>,
-        <ToggleButton value="center" key="center">
-            <FormatAlignCenterIcon />
-        </ToggleButton>,
-        <ToggleButton value="right" key="right">
-            <FormatAlignRightIcon />
-        </ToggleButton>,
-        <ToggleButton value="justify" key="justify">
-            <FormatAlignJustifyIcon />
-        </ToggleButton>,
-    ];
-
-    const childrenText = [
-        <ToggleButton value="left" key="left">
-            Left
-        </ToggleButton>,
-        <ToggleButton value="center" key="center">
-            Center
-        </ToggleButton>,
-        <ToggleButton value="right" key="right">
-            Right
-        </ToggleButton>,
-        <ToggleButton value="justify" key="justify">
-            Justify
-        </ToggleButton>,
-    ];
-
-    const sizes = ["small", "medium", "large"] as ButtonProps["size"][];
+    const sizes: ToggleButtonGroupProps["size"][] = ["small", "medium", "large"];
+    const orientations: ToggleButtonGroupProps["orientation"][] = ["horizontal", "vertical"];
     return (
-        <Stack spacing={2} alignItems="center">
-            <Typography variant="h6">ToggleButton</Typography>
+        <TestComponentContainer title="Toggle Button">
             {sizes.map((size) => (
-                <Stack direction="row" spacing={2} alignItems="center">
-                    <ToggleButtonGroup
-                        size={size}
-                        value={alignment}
-                        onChange={handleChange}
-                        exclusive>
-                        {childrenIcon}
-                    </ToggleButtonGroup>
-                    <ToggleButtonGroup
-                        size={size}
-                        value={alignment}
-                        onChange={handleChange}
-                        exclusive>
-                        {childrenText}
-                    </ToggleButtonGroup>
-                    <ToggleButtonGroup
-                        size={size}
-                        value={alignment}
-                        orientation="vertical"
-                        onChange={handleChange}
-                        exclusive>
-                        {childrenIcon}
-                    </ToggleButtonGroup>
-                    <ToggleButtonGroup
-                        size={size}
-                        value={alignment}
-                        orientation="vertical"
-                        onChange={handleChange}
-                        exclusive>
-                        {childrenText}
-                    </ToggleButtonGroup>
+                <Stack direction="row" spacing={2} alignItems="center" key={size}>
+                    <Typography variant="caption">{size}</Typography>
+                    {orientations.map((orientation) => (
+                        <>
+                            <ToggleButtonGroup
+                                size={size}
+                                value={alignment}
+                                orientation={orientation}
+                                onChange={handleChange}
+                                exclusive>
+                                <ToggleButton value="left" key="left">
+                                    <FormatAlignLeftIcon />
+                                </ToggleButton>
+                                <ToggleButton value="center" key="center">
+                                    <FormatAlignCenterIcon />
+                                </ToggleButton>
+                                <ToggleButton value="right" key="right">
+                                    <FormatAlignRightIcon />
+                                </ToggleButton>
+                                <ToggleButton value="justify" key="justify">
+                                    <FormatAlignJustifyIcon />
+                                </ToggleButton>
+                            </ToggleButtonGroup>
+                            <ToggleButtonGroup
+                                size={size}
+                                value={alignment}
+                                orientation={orientation}
+                                onChange={handleChange}
+                                exclusive>
+                                <ToggleButton value="left" key="left">
+                                    Left
+                                </ToggleButton>
+                                <ToggleButton value="center" key="center">
+                                    Center
+                                </ToggleButton>
+                                <ToggleButton value="right" key="right">
+                                    Right
+                                </ToggleButton>
+                                <ToggleButton value="justify" key="justify">
+                                    Justify
+                                </ToggleButton>
+                            </ToggleButtonGroup>
+                        </>
+                    ))}
                 </Stack>
             ))}
-        </Stack>
+        </TestComponentContainer>
     );
 }

--- a/src/theme/themeTest/buttons/ToggleButton.tsx
+++ b/src/theme/themeTest/buttons/ToggleButton.tsx
@@ -1,0 +1,89 @@
+import FormatAlignCenterIcon from "@mui/icons-material/FormatAlignCenter";
+import FormatAlignJustifyIcon from "@mui/icons-material/FormatAlignJustify";
+import FormatAlignLeftIcon from "@mui/icons-material/FormatAlignLeft";
+import FormatAlignRightIcon from "@mui/icons-material/FormatAlignRight";
+import { ButtonProps } from "@mui/material";
+import Stack from "@mui/material/Stack";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import Typography from "@mui/material/Typography";
+import * as React from "react";
+
+export function ToggleButtonTest() {
+    const [alignment, setAlignment] = React.useState("left");
+
+    const handleChange = (_event: React.MouseEvent<HTMLElement>, newAlignment: string) => {
+        setAlignment(newAlignment);
+    };
+
+    const childrenIcon = [
+        <ToggleButton value="left" key="left">
+            <FormatAlignLeftIcon />
+        </ToggleButton>,
+        <ToggleButton value="center" key="center">
+            <FormatAlignCenterIcon />
+        </ToggleButton>,
+        <ToggleButton value="right" key="right">
+            <FormatAlignRightIcon />
+        </ToggleButton>,
+        <ToggleButton value="justify" key="justify">
+            <FormatAlignJustifyIcon />
+        </ToggleButton>,
+    ];
+
+    const childrenText = [
+        <ToggleButton value="left" key="left">
+            Left
+        </ToggleButton>,
+        <ToggleButton value="center" key="center">
+            Center
+        </ToggleButton>,
+        <ToggleButton value="right" key="right">
+            Right
+        </ToggleButton>,
+        <ToggleButton value="justify" key="justify">
+            Justify
+        </ToggleButton>,
+    ];
+
+    const sizes = ["small", "medium", "large"] as ButtonProps["size"][];
+    return (
+        <Stack spacing={2} alignItems="center">
+            <Typography variant="h6">ToggleButton</Typography>
+            {sizes.map((size) => (
+                <Stack direction="row" spacing={2} alignItems="center">
+                    <ToggleButtonGroup
+                        size={size}
+                        value={alignment}
+                        onChange={handleChange}
+                        exclusive>
+                        {childrenIcon}
+                    </ToggleButtonGroup>
+                    <ToggleButtonGroup
+                        size={size}
+                        value={alignment}
+                        onChange={handleChange}
+                        exclusive>
+                        {childrenText}
+                    </ToggleButtonGroup>
+                    <ToggleButtonGroup
+                        size={size}
+                        value={alignment}
+                        orientation="vertical"
+                        onChange={handleChange}
+                        exclusive>
+                        {childrenIcon}
+                    </ToggleButtonGroup>
+                    <ToggleButtonGroup
+                        size={size}
+                        value={alignment}
+                        orientation="vertical"
+                        onChange={handleChange}
+                        exclusive>
+                        {childrenText}
+                    </ToggleButtonGroup>
+                </Stack>
+            ))}
+        </Stack>
+    );
+}

--- a/src/theme/themeTest/buttons/ToggleButton.tsx
+++ b/src/theme/themeTest/buttons/ToggleButton.tsx
@@ -25,7 +25,7 @@ export function ToggleButtonTest() {
                 <Stack direction="row" spacing={2} alignItems="center" key={size}>
                     <Typography variant="caption">{size}</Typography>
                     {orientations.map((orientation) => (
-                        <>
+                        <React.Fragment key={orientation}>
                             <ToggleButtonGroup
                                 size={size}
                                 value={alignment}
@@ -64,7 +64,7 @@ export function ToggleButtonTest() {
                                     Justify
                                 </ToggleButton>
                             </ToggleButtonGroup>
-                        </>
+                        </React.Fragment>
                     ))}
                 </Stack>
             ))}

--- a/src/theme/themeTest/inputs/Autocomplete.tsx
+++ b/src/theme/themeTest/inputs/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import Autocomplete, { AutocompleteProps } from "@mui/material/Autocomplete";
+import Autocomplete from "@mui/material/Autocomplete";
 import Stack from "@mui/material/Stack";
 import TextField, { TextFieldProps } from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
@@ -12,7 +12,7 @@ export function AutocompleteTest() {
     return (
         <TestComponentContainer title="Autocomplete">
             {sizes.map((size) => (
-                <Stack direction="row" spacing={1} key="size">
+                <Stack direction="row" spacing={1} key={size}>
                     <Typography variant="caption">{size}</Typography>
                     {variants.map((variant) => (
                         <Autocomplete
@@ -25,6 +25,7 @@ export function AutocompleteTest() {
                                 // eslint-disable-next-line react/jsx-props-no-spreading
                                 <TextField {...params} label="Movie" variant={variant} />
                             )}
+                            key={variant}
                         />
                     ))}
                 </Stack>

--- a/src/theme/themeTest/inputs/Autocomplete.tsx
+++ b/src/theme/themeTest/inputs/Autocomplete.tsx
@@ -1,47 +1,40 @@
-import Autocomplete from "@mui/material/Autocomplete";
+import Autocomplete, { AutocompleteProps } from "@mui/material/Autocomplete";
 import Stack from "@mui/material/Stack";
-import TextField from "@mui/material/TextField";
+import TextField, { TextFieldProps } from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import * as React from "react";
+import React from "react";
 
-function AutocompleteVariants({
-    size,
-    variant,
-}: {
-    size: "small" | "medium";
-    variant: "standard" | "filled" | "outlined";
-}) {
-    return (
-        <Autocomplete
-            disablePortal
-            id="combo-box-demo"
-            // eslint-disable-next-line @typescript-eslint/no-use-before-define
-            options={top20Films}
-            size={size}
-            // eslint-disable-next-line react/jsx-props-no-spreading
-            renderInput={(params) => <TextField {...params} label="Movie" variant={variant} />}
-        />
-    );
-}
+import TestComponentContainer from "../TestComponentContainer";
 
-const sizes = ["small", "medium"] as ("small" | "medium")[];
 export function AutocompleteTest() {
+    const sizes: TextFieldProps["size"][] = ["small", "medium"];
+    const variants: TextFieldProps["variant"][] = ["outlined", "filled", "standard"];
     return (
-        <Stack spacing={2} alignItems="center">
-            <Typography variant="h6">Autocomplete</Typography>
+        <TestComponentContainer title="Autocomplete">
             {sizes.map((size) => (
-                <Stack direction="row" spacing={1}>
-                    <AutocompleteVariants size={size} variant="outlined" />
-                    <AutocompleteVariants size={size} variant="filled" />
-                    <AutocompleteVariants size={size} variant="standard" />
+                <Stack direction="row" spacing={1} key="size">
+                    <Typography variant="caption">{size}</Typography>
+                    {variants.map((variant) => (
+                        <Autocomplete
+                            disablePortal
+                            id="combo-box-demo"
+                            // eslint-disable-next-line @typescript-eslint/no-use-before-define
+                            options={top10Films}
+                            size={size}
+                            renderInput={(params) => (
+                                // eslint-disable-next-line react/jsx-props-no-spreading
+                                <TextField {...params} label="Movie" variant={variant} />
+                            )}
+                        />
+                    ))}
                 </Stack>
             ))}
-        </Stack>
+        </TestComponentContainer>
     );
 }
 
-// Top 20 films as rated by IMDb users. http://www.imdb.com/chart/top
-const top20Films = [
+// Top 10 films as rated by IMDb users. http://www.imdb.com/chart/top
+const top10Films = [
     { label: "The Shawshank Redemption", year: 1994 },
     { label: "The Godfather", year: 1972 },
     { label: "The Godfather: Part II", year: 1974 },
@@ -55,26 +48,4 @@ const top20Films = [
     },
     { label: "The Good, the Bad and the Ugly", year: 1966 },
     { label: "Fight Club", year: 1999 },
-    {
-        label: "The Lord of the Rings: The Fellowship of the Ring",
-        year: 2001,
-    },
-    {
-        label: "Star Wars: Episode V - The Empire Strikes Back",
-        year: 1980,
-    },
-    { label: "Forrest Gump", year: 1994 },
-    { label: "Inception", year: 2010 },
-    {
-        label: "The Lord of the Rings: The Two Towers",
-        year: 2002,
-    },
-    { label: "One Flew Over the Cuckoo's Nest", year: 1975 },
-    { label: "Goodfellas", year: 1990 },
-    { label: "The Matrix", year: 1999 },
-    { label: "Seven Samurai", year: 1954 },
-    {
-        label: "Star Wars: Episode IV - A New Hope",
-        year: 1977,
-    },
 ];

--- a/src/theme/themeTest/inputs/Autocomplete.tsx
+++ b/src/theme/themeTest/inputs/Autocomplete.tsx
@@ -1,0 +1,80 @@
+import Autocomplete from "@mui/material/Autocomplete";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import * as React from "react";
+
+function AutocompleteVariants({
+    size,
+    variant,
+}: {
+    size: "small" | "medium";
+    variant: "standard" | "filled" | "outlined";
+}) {
+    return (
+        <Autocomplete
+            disablePortal
+            id="combo-box-demo"
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define
+            options={top20Films}
+            size={size}
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            renderInput={(params) => <TextField {...params} label="Movie" variant={variant} />}
+        />
+    );
+}
+
+const sizes = ["small", "medium"] as ("small" | "medium")[];
+export function AutocompleteTest() {
+    return (
+        <Stack spacing={2} alignItems="center">
+            <Typography variant="subtitle1">Autocomplete</Typography>
+            {sizes.map((size) => (
+                <Stack direction="row" spacing={1}>
+                    <AutocompleteVariants size={size} variant="outlined" />
+                    <AutocompleteVariants size={size} variant="filled" />
+                    <AutocompleteVariants size={size} variant="standard" />
+                </Stack>
+            ))}
+        </Stack>
+    );
+}
+
+// Top 20 films as rated by IMDb users. http://www.imdb.com/chart/top
+const top20Films = [
+    { label: "The Shawshank Redemption", year: 1994 },
+    { label: "The Godfather", year: 1972 },
+    { label: "The Godfather: Part II", year: 1974 },
+    { label: "The Dark Knight", year: 2008 },
+    { label: "12 Angry Men", year: 1957 },
+    { label: "Schindler's List", year: 1993 },
+    { label: "Pulp Fiction", year: 1994 },
+    {
+        label: "The Lord of the Rings: The Return of the King",
+        year: 2003,
+    },
+    { label: "The Good, the Bad and the Ugly", year: 1966 },
+    { label: "Fight Club", year: 1999 },
+    {
+        label: "The Lord of the Rings: The Fellowship of the Ring",
+        year: 2001,
+    },
+    {
+        label: "Star Wars: Episode V - The Empire Strikes Back",
+        year: 1980,
+    },
+    { label: "Forrest Gump", year: 1994 },
+    { label: "Inception", year: 2010 },
+    {
+        label: "The Lord of the Rings: The Two Towers",
+        year: 2002,
+    },
+    { label: "One Flew Over the Cuckoo's Nest", year: 1975 },
+    { label: "Goodfellas", year: 1990 },
+    { label: "The Matrix", year: 1999 },
+    { label: "Seven Samurai", year: 1954 },
+    {
+        label: "Star Wars: Episode IV - A New Hope",
+        year: 1977,
+    },
+];

--- a/src/theme/themeTest/inputs/Autocomplete.tsx
+++ b/src/theme/themeTest/inputs/Autocomplete.tsx
@@ -12,7 +12,7 @@ export function AutocompleteTest() {
     return (
         <TestComponentContainer title="Autocomplete">
             {sizes.map((size) => (
-                <Stack direction="row" spacing={1} key={size}>
+                <Stack direction="row" spacing={1} alignItems="center" key={size}>
                     <Typography variant="caption">{size}</Typography>
                     {variants.map((variant) => (
                         <Autocomplete

--- a/src/theme/themeTest/inputs/Autocomplete.tsx
+++ b/src/theme/themeTest/inputs/Autocomplete.tsx
@@ -28,7 +28,7 @@ const sizes = ["small", "medium"] as ("small" | "medium")[];
 export function AutocompleteTest() {
     return (
         <Stack spacing={2} alignItems="center">
-            <Typography variant="subtitle1">Autocomplete</Typography>
+            <Typography variant="h6">Autocomplete</Typography>
             {sizes.map((size) => (
                 <Stack direction="row" spacing={1}>
                     <AutocompleteVariants size={size} variant="outlined" />

--- a/src/theme/themeTest/inputs/Select.tsx
+++ b/src/theme/themeTest/inputs/Select.tsx
@@ -47,7 +47,7 @@ export function SelectTest() {
     return (
         <TestComponentContainer title="Select">
             {sizes.map((size) => (
-                <Stack direction="row" spacing={2} key="size">
+                <Stack direction="row" spacing={2} alignItems="center" key={size}>
                     <Typography variant="caption">{size}</Typography>
                     <FormControl size={size}>
                         <InputLabel id="select-small-label">Age</InputLabel>

--- a/src/theme/themeTest/inputs/Select.tsx
+++ b/src/theme/themeTest/inputs/Select.tsx
@@ -66,7 +66,7 @@ export function SelectTest() {
 
     return (
         <Stack spacing={2} alignItems="center">
-            <Typography variant="subtitle1">Select</Typography>
+            <Typography variant="h6">Select</Typography>
             {sizes.map((size) => (
                 <Stack direction="row" spacing={2}>
                     <FormControl size={size}>

--- a/src/theme/themeTest/inputs/Select.tsx
+++ b/src/theme/themeTest/inputs/Select.tsx
@@ -1,0 +1,120 @@
+import Chip from "@mui/material/Chip";
+import FormControl, { FormControlProps } from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import OutlinedInput from "@mui/material/OutlinedInput";
+import Select, { SelectChangeEvent } from "@mui/material/Select";
+import Stack from "@mui/material/Stack";
+import { Theme, useTheme } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import React from "react";
+
+const ITEM_HEIGHT = 48;
+const ITEM_PADDING_TOP = 8;
+const MenuProps = {
+    PaperProps: {
+        style: {
+            maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
+            width: 250,
+        },
+    },
+};
+
+const names = [
+    "Oliver Hansen",
+    "Van Henry",
+    "April Tucker",
+    "Ralph Hubbard",
+    "Omar Alexander",
+    "Carlos Abbott",
+    "Miriam Wagner",
+    "Bradley Wilkerson",
+    "Virginia Andrews",
+    "Kelly Snyder",
+];
+
+function getStyles(name: string, personName: readonly string[], theme: Theme) {
+    return {
+        fontWeight:
+            personName.indexOf(name) === -1
+                ? theme.typography.fontWeightRegular
+                : theme.typography.fontWeightMedium,
+    };
+}
+
+export function SelectTest() {
+    const theme = useTheme();
+    const [personName, setPersonName] = React.useState<string[]>([]);
+
+    const handleNameChange = (event: SelectChangeEvent<typeof personName>) => {
+        const {
+            target: { value },
+        } = event;
+        setPersonName(
+            // On autofill we get a stringified value.
+            typeof value === "string" ? value.split(",") : value,
+        );
+    };
+
+    const [age, setAge] = React.useState("");
+
+    const handleAgeChange = (event: SelectChangeEvent) => {
+        setAge(event.target.value);
+    };
+
+    const sizes = ["small", undefined] as FormControlProps["size"][];
+
+    return (
+        <Stack spacing={2} alignItems="center">
+            <Typography variant="subtitle1">Select</Typography>
+            {sizes.map((size) => (
+                <Stack direction="row" spacing={2}>
+                    <FormControl size={size}>
+                        <InputLabel id="demo-select-small-label">Age</InputLabel>
+                        <Select
+                            labelId="demo-select-small-label"
+                            id="demo-select-small"
+                            value={age}
+                            label="Age"
+                            onChange={handleAgeChange}>
+                            <MenuItem value="">
+                                <em>None</em>
+                            </MenuItem>
+                            <MenuItem value={10}>Ten</MenuItem>
+                            <MenuItem value={20}>Twenty</MenuItem>
+                            <MenuItem value={30}>Thirty</MenuItem>
+                        </Select>
+                    </FormControl>
+                    <FormControl size={size}>
+                        <InputLabel id="demo-multiple-chip-label">Chip</InputLabel>
+                        <Select
+                            labelId="demo-multiple-chip-label"
+                            id="demo-multiple-chip"
+                            multiple
+                            value={personName}
+                            sx={{ maxWidth: "300px" }}
+                            onChange={handleNameChange}
+                            input={<OutlinedInput id="select-multiple-chip" label="Chip" />}
+                            renderValue={(selected) => (
+                                <Stack direction="row" useFlexGap flexWrap="wrap" gap={0.5}>
+                                    {selected.map((value) => (
+                                        <Chip key={value} label={value} />
+                                    ))}
+                                </Stack>
+                            )}
+                            MenuProps={MenuProps}>
+                            {names.map((name) => (
+                                <MenuItem
+                                    key={name}
+                                    value={name}
+                                    style={getStyles(name, personName, theme)}>
+                                    {name}
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </FormControl>
+                </Stack>
+            ))}
+        </Stack>
+    );
+}

--- a/src/theme/themeTest/inputs/Select.tsx
+++ b/src/theme/themeTest/inputs/Select.tsx
@@ -56,6 +56,7 @@ export function SelectTest() {
                             id="select-small"
                             value={age}
                             label="Age"
+                            size={size}
                             onChange={handleAgeChange}>
                             <MenuItem value="">
                                 <em>None</em>
@@ -74,6 +75,7 @@ export function SelectTest() {
                             value={personName}
                             sx={{ maxWidth: "300px" }} // required to prevent overflow
                             onChange={handleNameChange}
+                            size={size}
                             input={<OutlinedInput id="select-multiselect-chip" label="Chip" />}
                             renderValue={(selected) => (
                                 <Stack direction="row" useFlexGap flexWrap="wrap" gap={0.5}>

--- a/src/theme/themeTest/inputs/Select.tsx
+++ b/src/theme/themeTest/inputs/Select.tsx
@@ -5,20 +5,10 @@ import MenuItem from "@mui/material/MenuItem";
 import OutlinedInput from "@mui/material/OutlinedInput";
 import Select, { SelectChangeEvent } from "@mui/material/Select";
 import Stack from "@mui/material/Stack";
-import { Theme, useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import React from "react";
 
-const ITEM_HEIGHT = 48;
-const ITEM_PADDING_TOP = 8;
-const MenuProps = {
-    PaperProps: {
-        style: {
-            maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
-            width: 250,
-        },
-    },
-};
+import TestComponentContainer from "../TestComponentContainer";
 
 const names = [
     "Oliver Hansen",
@@ -33,17 +23,7 @@ const names = [
     "Kelly Snyder",
 ];
 
-function getStyles(name: string, personName: readonly string[], theme: Theme) {
-    return {
-        fontWeight:
-            personName.indexOf(name) === -1
-                ? theme.typography.fontWeightRegular
-                : theme.typography.fontWeightMedium,
-    };
-}
-
 export function SelectTest() {
-    const theme = useTheme();
     const [personName, setPersonName] = React.useState<string[]>([]);
 
     const handleNameChange = (event: SelectChangeEvent<typeof personName>) => {
@@ -62,18 +42,18 @@ export function SelectTest() {
         setAge(event.target.value);
     };
 
-    const sizes = ["small", undefined] as FormControlProps["size"][];
+    const sizes: FormControlProps["size"][] = ["small", "medium"];
 
     return (
-        <Stack spacing={2} alignItems="center">
-            <Typography variant="h6">Select</Typography>
+        <TestComponentContainer title="Select">
             {sizes.map((size) => (
-                <Stack direction="row" spacing={2}>
+                <Stack direction="row" spacing={2} key="size">
+                    <Typography variant="caption">{size}</Typography>
                     <FormControl size={size}>
-                        <InputLabel id="demo-select-small-label">Age</InputLabel>
+                        <InputLabel id="select-small-label">Age</InputLabel>
                         <Select
-                            labelId="demo-select-small-label"
-                            id="demo-select-small"
+                            labelId="select-small-label"
+                            id="select-small"
                             value={age}
                             label="Age"
                             onChange={handleAgeChange}>
@@ -86,28 +66,24 @@ export function SelectTest() {
                         </Select>
                     </FormControl>
                     <FormControl size={size}>
-                        <InputLabel id="demo-multiple-chip-label">Chip</InputLabel>
+                        <InputLabel id="multiselect-chip-label">Chip</InputLabel>
                         <Select
-                            labelId="demo-multiple-chip-label"
-                            id="demo-multiple-chip"
+                            labelId="multiselect-chip-label"
+                            id="multiselect-chip"
                             multiple
                             value={personName}
-                            sx={{ maxWidth: "300px" }}
+                            sx={{ maxWidth: "300px" }} // required to prevent overflow
                             onChange={handleNameChange}
-                            input={<OutlinedInput id="select-multiple-chip" label="Chip" />}
+                            input={<OutlinedInput id="select-multiselect-chip" label="Chip" />}
                             renderValue={(selected) => (
                                 <Stack direction="row" useFlexGap flexWrap="wrap" gap={0.5}>
                                     {selected.map((value) => (
                                         <Chip key={value} label={value} />
                                     ))}
                                 </Stack>
-                            )}
-                            MenuProps={MenuProps}>
+                            )}>
                             {names.map((name) => (
-                                <MenuItem
-                                    key={name}
-                                    value={name}
-                                    style={getStyles(name, personName, theme)}>
+                                <MenuItem key={name} value={name}>
                                     {name}
                                 </MenuItem>
                             ))}
@@ -115,6 +91,6 @@ export function SelectTest() {
                     </FormControl>
                 </Stack>
             ))}
-        </Stack>
+        </TestComponentContainer>
     );
 }

--- a/src/theme/themeTest/inputs/TextField.tsx
+++ b/src/theme/themeTest/inputs/TextField.tsx
@@ -11,10 +11,16 @@ export function TextFieldTest() {
     return (
         <TestComponentContainer title="TextField">
             {sizes.map((size) => (
-                <Stack spacing={2} direction="row" component="form" noValidate autoComplete="off">
+                <Stack
+                    spacing={2}
+                    direction="row"
+                    component="form"
+                    noValidate
+                    autoComplete="off"
+                    key={size}>
                     <Typography variant="caption">{size}</Typography>
                     {variants.map((variant) => (
-                        <TextField label={variant} variant={variant} size={size} />
+                        <TextField label={variant} variant={variant} size={size} key={variant} />
                     ))}
                 </Stack>
             ))}

--- a/src/theme/themeTest/inputs/TextField.tsx
+++ b/src/theme/themeTest/inputs/TextField.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 export function TextFieldTest() {
     return (
         <Stack spacing={2} alignItems="center">
-            <Typography variant="subtitle1">TextField</Typography>
+            <Typography variant="h6">TextField</Typography>
             <Stack spacing={2} direction="row" component="form" noValidate autoComplete="off">
                 <TextField id="outlined-basic" label="Outlined" variant="outlined" size="small" />
                 <TextField id="filled-basic" label="Filled" variant="filled" size="small" />

--- a/src/theme/themeTest/inputs/TextField.tsx
+++ b/src/theme/themeTest/inputs/TextField.tsx
@@ -1,0 +1,22 @@
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import * as React from "react";
+
+export function TextFieldTest() {
+    return (
+        <Stack spacing={2} alignItems="center">
+            <Typography variant="subtitle1">TextField</Typography>
+            <Stack spacing={2} direction="row" component="form" noValidate autoComplete="off">
+                <TextField id="outlined-basic" label="Outlined" variant="outlined" size="small" />
+                <TextField id="filled-basic" label="Filled" variant="filled" size="small" />
+                <TextField id="standard-basic" label="Standard" variant="standard" size="small" />
+            </Stack>
+            <Stack spacing={2} direction="row" component="form" noValidate autoComplete="off">
+                <TextField id="outlined-basic" label="Outlined" variant="outlined" size="medium" />
+                <TextField id="filled-basic" label="Filled" variant="filled" size="medium" />
+                <TextField id="standard-basic" label="Standard" variant="standard" size="medium" />
+            </Stack>
+        </Stack>
+    );
+}

--- a/src/theme/themeTest/inputs/TextField.tsx
+++ b/src/theme/themeTest/inputs/TextField.tsx
@@ -14,6 +14,7 @@ export function TextFieldTest() {
                 <Stack
                     spacing={2}
                     direction="row"
+                    alignItems="center"
                     component="form"
                     noValidate
                     autoComplete="off"

--- a/src/theme/themeTest/inputs/TextField.tsx
+++ b/src/theme/themeTest/inputs/TextField.tsx
@@ -1,22 +1,23 @@
 import Stack from "@mui/material/Stack";
-import TextField from "@mui/material/TextField";
+import TextField, { TextFieldProps } from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import * as React from "react";
+import React from "react";
+
+import TestComponentContainer from "../TestComponentContainer";
 
 export function TextFieldTest() {
+    const sizes: TextFieldProps["size"][] = ["small", "medium"];
+    const variants: TextFieldProps["variant"][] = ["outlined", "filled", "standard"];
     return (
-        <Stack spacing={2} alignItems="center">
-            <Typography variant="h6">TextField</Typography>
-            <Stack spacing={2} direction="row" component="form" noValidate autoComplete="off">
-                <TextField id="outlined-basic" label="Outlined" variant="outlined" size="small" />
-                <TextField id="filled-basic" label="Filled" variant="filled" size="small" />
-                <TextField id="standard-basic" label="Standard" variant="standard" size="small" />
-            </Stack>
-            <Stack spacing={2} direction="row" component="form" noValidate autoComplete="off">
-                <TextField id="outlined-basic" label="Outlined" variant="outlined" size="medium" />
-                <TextField id="filled-basic" label="Filled" variant="filled" size="medium" />
-                <TextField id="standard-basic" label="Standard" variant="standard" size="medium" />
-            </Stack>
-        </Stack>
+        <TestComponentContainer title="TextField">
+            {sizes.map((size) => (
+                <Stack spacing={2} direction="row" component="form" noValidate autoComplete="off">
+                    <Typography variant="caption">{size}</Typography>
+                    {variants.map((variant) => (
+                        <TextField label={variant} variant={variant} size={size} />
+                    ))}
+                </Stack>
+            ))}
+        </TestComponentContainer>
     );
 }

--- a/src/theme/themeTest/typography/Typography.tsx
+++ b/src/theme/themeTest/typography/Typography.tsx
@@ -1,0 +1,25 @@
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import React from "react";
+
+export function TypographyTest() {
+    return (
+        <Stack spacing={2} alignItems="center">
+            <Typography variant="subtitle1">Typography</Typography>
+            <Typography variant="h1">h1</Typography>
+            <Typography variant="h2">h2</Typography>
+            <Typography variant="h3">h3</Typography>
+            <Typography variant="h4">h4</Typography>
+            <Typography variant="h5">h5</Typography>
+            <Typography variant="h6">h6</Typography>
+            <Typography variant="subtitle1">subtitle1</Typography>
+            <Typography variant="subtitle2">subtitle2</Typography>
+            <Typography variant="body1">body1</Typography>
+            <Typography variant="body2">body2</Typography>
+            <Typography variant="caption">caption</Typography>
+            <Typography variant="button">button</Typography>
+        </Stack>
+    );
+}
+
+export default Typography;

--- a/src/theme/themeTest/typography/Typography.tsx
+++ b/src/theme/themeTest/typography/Typography.tsx
@@ -21,7 +21,9 @@ export function TypographyTest() {
     return (
         <TestComponentContainer title="Typography">
             {variants.map((variant) => (
-                <Typography variant={variant}>{variant}</Typography>
+                <Typography variant={variant} key={variant}>
+                    {variant}
+                </Typography>
             ))}
         </TestComponentContainer>
     );

--- a/src/theme/themeTest/typography/Typography.tsx
+++ b/src/theme/themeTest/typography/Typography.tsx
@@ -1,24 +1,29 @@
-import Stack from "@mui/material/Stack";
-import Typography from "@mui/material/Typography";
+import Typography, { TypographyProps } from "@mui/material/Typography";
 import React from "react";
 
+import TestComponentContainer from "../TestComponentContainer";
+
 export function TypographyTest() {
+    const variants: TypographyProps["variant"][] = [
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "subtitle1",
+        "subtitle2",
+        "body1",
+        "body2",
+        "caption",
+        "button",
+    ];
     return (
-        <Stack spacing={2} alignItems="center">
-            <Typography variant="h6">Typography</Typography>
-            <Typography variant="h1">h1</Typography>
-            <Typography variant="h2">h2</Typography>
-            <Typography variant="h3">h3</Typography>
-            <Typography variant="h4">h4</Typography>
-            <Typography variant="h5">h5</Typography>
-            <Typography variant="h6">h6</Typography>
-            <Typography variant="subtitle1">subtitle1</Typography>
-            <Typography variant="subtitle2">subtitle2</Typography>
-            <Typography variant="body1">body1</Typography>
-            <Typography variant="body2">body2</Typography>
-            <Typography variant="caption">caption</Typography>
-            <Typography variant="button">button</Typography>
-        </Stack>
+        <TestComponentContainer title="Typography">
+            {variants.map((variant) => (
+                <Typography variant={variant}>{variant}</Typography>
+            ))}
+        </TestComponentContainer>
     );
 }
 

--- a/src/theme/themeTest/typography/Typography.tsx
+++ b/src/theme/themeTest/typography/Typography.tsx
@@ -5,7 +5,7 @@ import React from "react";
 export function TypographyTest() {
     return (
         <Stack spacing={2} alignItems="center">
-            <Typography variant="subtitle1">Typography</Typography>
+            <Typography variant="h6">Typography</Typography>
             <Typography variant="h1">h1</Typography>
             <Typography variant="h2">h2</Typography>
             <Typography variant="h3">h3</Typography>

--- a/src/theme/typography/index.ts
+++ b/src/theme/typography/index.ts
@@ -1,66 +1,24 @@
 import { Theme } from "@mui/material/styles";
 
-const oldTypography = (theme: Theme): Partial<Theme["typography"]> => {
+const Typography = (theme: Theme): Partial<Theme["typography"]> => {
     return {
         fontFamily: ["Roboto", "-apple-system", "sans-serif"].join(","),
-        h1: {
-            fontSize: "96px",
-            color: theme.palette.text.primary,
-        },
-        h2: {
-            fontSize: "60px",
-            color: theme.palette.text.primary,
-        },
-        h3: {
-            fontSize: "48px",
-            color: theme.palette.text.primary,
-        },
-        h4: {
-            fontSize: "34px",
-            color: theme.palette.text.primary,
-        },
-        h5: {
-            fontSize: "24px",
-            color: theme.palette.text.primary,
-        },
-        h6: {
-            fontSize: "20px",
-            color: theme.palette.text.primary,
-        },
-        subtitle1: {
-            fontSize: "16px",
-            color: theme.palette.text.primary,
-        },
         subtitle2: {
-            fontSize: "14px",
             color: theme.palette.text.secondary,
-        },
-        body1: {
-            fontSize: "16px",
-            color: theme.palette.text.primary,
         },
         body2: {
-            fontSize: "14px",
             color: theme.palette.text.secondary,
-        },
-        overline: {
-            fontSize: "12px",
-            textTransform: "uppercase",
         },
         caption: {
-            fontSize: "12px",
             color: theme.palette.text.secondary,
-        },
-        button: {
-            fontSize: "14px",
         },
     };
 };
 
-export default oldTypography;
+export default Typography;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const Typography = (theme: Theme): Partial<Theme["typography"]> => {
+export const MDTypography = (theme: Theme): Partial<Theme["typography"]> => {
     return {
         fontFamily: ["Roboto", "-apple-system", "sans-serif"].join(","),
         body1: {

--- a/src/theme/typography/index.ts
+++ b/src/theme/typography/index.ts
@@ -1,8 +1,13 @@
 import { Theme } from "@mui/material/styles";
 
-const Typography = (theme: Theme): Partial<Theme["typography"]> => {
+import { type CommonSettings } from "../theme";
+
+export const typography = (
+    theme: Theme,
+    commonSettings: CommonSettings,
+): Partial<Theme["typography"]> => {
     return {
-        fontFamily: ["Roboto", "-apple-system", "sans-serif"].join(","),
+        fontFamily: commonSettings.fonts.roboto,
         subtitle2: {
             color: theme.palette.text.secondary,
         },
@@ -15,12 +20,13 @@ const Typography = (theme: Theme): Partial<Theme["typography"]> => {
     };
 };
 
-export default Typography;
-
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const MDTypography = (theme: Theme): Partial<Theme["typography"]> => {
+export const MDTypography = (
+    theme: Theme,
+    commonSettings: CommonSettings,
+): Partial<Theme["typography"]> => {
     return {
-        fontFamily: ["Roboto", "-apple-system", "sans-serif"].join(","),
+        fontFamily: commonSettings.fonts.roboto,
         body1: {
             fontSize: 12,
         },


### PR DESCRIPTION
This PR aims to improve default MUI stylings by adjusting the sizes and paddings of buttons and input elements to create elements of a consistent size and improve their container filling behavior.
- add a ThemeTest component to show an assortment of components using the app's current theme
   - add test components for MUI components
- removed `selected` variant from theme
- modify the sizes of buttons to constant height
- modify the spacing of input elements and their labels to match button height
  - small input = medium button
  - medium input = large button
  - modify the chip size in input elements to prevent layout shift
  - remove `minHeight` from `Select` component
- revert typography sizes to MUI default to restore font scaling with `htmlFontSize`:  see mui explanation [here](https://mui.com/material-ui/customization/typography/#html-font-size)