### PR TITLE
chore: pin codemirror/lang-python version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1351,12 +1351,14 @@
             }
         },
         "@codemirror/lang-python": {
-            "version": "6.1.3",
-            "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.1.3.tgz",
-            "integrity": "sha512-S9w2Jl74hFlD5nqtUMIaXAq9t5WlM0acCkyuQWUUSvZclk1sV+UfnpFiZzuZSG+hfEaOmxKR5UxY/Uxswn7EhQ==",
+            "version": "6.1.5",
+            "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.1.5.tgz",
+            "integrity": "sha512-hCm+8X6wrnXJCGf+QhmFu1AXkdTVG7dHy0Ly6SI1N3SRPptaMvwX6oNQonOXOMPvmcjiB0xq342KAxX3BYpijw==",
             "requires": {
                 "@codemirror/autocomplete": "^6.3.2",
                 "@codemirror/language": "^6.8.0",
+                "@codemirror/state": "^6.0.0",
+                "@lezer/common": "^1.2.1",
                 "@lezer/python": "^1.1.4"
             }
         },
@@ -1831,9 +1833,9 @@
             }
         },
         "@lezer/python": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.11.tgz",
-            "integrity": "sha512-C3QeLCcdAKJDUOsYjfFP6a1wdn8jhUNX200bgFm8TpKH1eM2PlgYQS5ugw6E38qGeEx7CP21I1Q52SoybXt0OQ==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.13.tgz",
+            "integrity": "sha512-AdbRAtdQq94PfTNd4kqMEJhH2fqa2JdoyyqqVewY6w34w2Gi6dg2JuOtOgR21Bi0zP9r0KjSSHOUq/tP7FVT8A==",
             "requires": {
                 "@lezer/common": "^1.2.0",
                 "@lezer/highlight": "^1.0.0",
@@ -7257,7 +7259,7 @@
         },
         "react": {
             "version": "17.0.2",
-            "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+            "resolved": false,
             "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
             "dev": true,
             "requires": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "@codemirror/autocomplete": "^6.4.2",
         "@codemirror/lang-javascript": "^6.1.4",
         "@codemirror/lang-json": "^6.0.1",
-        "@codemirror/lang-python": "^6.1.2",
+        "@codemirror/lang-python": "6.1.5",
         "@codemirror/language": "^6.6.0",
         "@codemirror/legacy-modes": "^6.3.1",
         "@codemirror/lint": "^6.2.0",


### PR DESCRIPTION
Version 6.1.6 of CodeMirror/lang-python added continuing indentation, that messes with type() command of Cypress.
Pinning to previous working

Caused by this commit: https://github.com/codemirror/lang-python/commit/0468622ddfee9c2a0011544c8f3128749b714168