### PR TITLE
feat: add RJSF schema resolution utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .nyc_output/
 .idea/
 **/.DS_Store
+*.tgz

--- a/dist/mui/components/custom/date-picker/DatePicker.styled.d.ts
+++ b/dist/mui/components/custom/date-picker/DatePicker.styled.d.ts
@@ -1,4 +1,6 @@
-export declare const DatePickerButtonsContainer: StyledComponent<ComponentProps, SpecificComponentProps, JSXProps>;
-export declare const StyledPopover: StyledComponent<ComponentProps, SpecificComponentProps, JSXProps>;
-export declare const StyledDatePicker: StyledComponent<ComponentProps, SpecificComponentProps, JSXProps>;
-export declare const StyledDatePickerContainer: StyledComponent<ComponentProps, SpecificComponentProps, JSXProps>;
+/// <reference types="react" />
+import { Theme } from "@mui/material/styles";
+export declare const DatePickerButtonsContainer: import("@emotion/styled").StyledComponent<import("@mui/system").MUIStyledCommonProps<Theme>, import("react").DetailedHTMLProps<import("react").HTMLAttributes<HTMLDivElement>, HTMLDivElement>, {}>;
+export declare const StyledPopover: import("@emotion/styled").StyledComponent<import("@mui/material/Popover").PopoverProps & import("@mui/system").MUIStyledCommonProps<Theme>, {}, {}>;
+export declare const StyledDatePicker: import("@emotion/styled").StyledComponent<import("@mui/x-date-pickers/DatePicker").DatePickerProps<unknown> & import("react").RefAttributes<HTMLDivElement> & import("@mui/system").MUIStyledCommonProps<Theme>, {}, {}>;
+export declare const StyledDatePickerContainer: import("@emotion/styled").StyledComponent<import("@mui/system").MUIStyledCommonProps<Theme>, import("react").DetailedHTMLProps<import("react").HTMLAttributes<HTMLDivElement>, HTMLDivElement>, {}>;

--- a/dist/mui/components/stepper/Stepper.d.ts
+++ b/dist/mui/components/stepper/Stepper.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-export declare const StyledStepConnector: StyledComponent<ComponentProps, SpecificComponentProps, JSXProps>;
+export declare const StyledStepConnector: import("@emotion/styled").StyledComponent<import("@mui/material/StepConnector").StepConnectorProps & import("@mui/system").MUIStyledCommonProps<import("@mui/material/styles").Theme>, {}, {}>;
 export interface StyledStepperProps {
     activeStep: number;
     steps: string[];

--- a/dist/other/rjsf/schemaUtils.d.ts
+++ b/dist/other/rjsf/schemaUtils.d.ts
@@ -1,0 +1,43 @@
+import type { JSONSchema7 } from "json-schema";
+/**
+ * A registry type mapping schema IDs to their raw JSON content.
+ * Consumers provide this when constructing a UISchema so the schema
+ * resolution stays decoupled from any particular set of UI schemas.
+ */
+export type UISchemaRegistry = Record<string, any>;
+/**
+ * Wraps a raw UI schema object with `$val.*` variable resolution
+ * and `allOf.$ref` composition support.
+ *
+ * @example
+ * ```ts
+ * const registry: UISchemaRegistry = { "job/compute/base": baseSchema };
+ * const uiSchema = new UISchema(registry["job/compute/base"], registry);
+ * const resolved = uiSchema.resolveSchemaValues({ ppPerNode: 4 });
+ * ```
+ */
+export declare class UISchema {
+    private schema;
+    private resolvedSchema;
+    private registry;
+    constructor(schema: any, registry?: UISchemaRegistry);
+    resolveSchemaValues(schemaValues: any): any;
+    resolveSchema(): void;
+}
+/**
+ * Resolve a JSON schema by ID from the ESSE schema registry.
+ *
+ * @param schemaId - The ESSE schema identifier.
+ * @param removeRequired - If true, strips the `required` field from the result.
+ * @returns The resolved JSON schema, or an empty object if not found.
+ */
+export declare function resolveJsonSchema(schemaId: string, removeRequired?: boolean): JSONSchema7;
+/**
+ * Convenience factory: look up a UI schema by ID from a registry and wrap it
+ * in a {@link UISchema} instance.
+ *
+ * @param schemaId - Key into the `registry` map.
+ * @param registry - A map of schema IDs to raw JSON objects.
+ * @throws If the schema ID is not found in the registry.
+ */
+export declare function resolveUISchema(schemaId: string, registry: UISchemaRegistry): UISchema;

--- a/dist/other/rjsf/schemaUtils.js
+++ b/dist/other/rjsf/schemaUtils.js
@@ -1,0 +1,118 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import JSONSchemasInterface from "@mat3ra/esse/dist/js/esse/JSONSchemasInterface";
+/**
+ * Generic deep-map for plain objects. Recursively applies `mapValue` to each
+ * plain-object node. If `mapValue` returns a truthy value, that value replaces
+ * the node (its children are still traversed). Non-plain objects, primitives,
+ * and arrays of primitives are returned unchanged.
+ *
+ * NOTE: A copy of this function also lives in @mat3ra/utils (object module).
+ * We inline it here to avoid adding @mat3ra/utils as a dependency of cove.
+ */
+function mapObjectDeep(object, mapValue) {
+    if (typeof object !== "object" || object === null) {
+        return object;
+    }
+    if (Array.isArray(object)) {
+        return object.map((innerValue) => mapObjectDeep(innerValue, mapValue));
+    }
+    if (object.constructor !== Object) {
+        return object;
+    }
+    const mappedObject = mapValue(object) || object;
+    const entries = Object.entries(mappedObject).map(([key, value]) => {
+        return [key, mapObjectDeep(value, mapValue)];
+    });
+    return Object.fromEntries(entries);
+}
+/**
+ * Wraps a raw UI schema object with `$val.*` variable resolution
+ * and `allOf.$ref` composition support.
+ *
+ * @example
+ * ```ts
+ * const registry: UISchemaRegistry = { "job/compute/base": baseSchema };
+ * const uiSchema = new UISchema(registry["job/compute/base"], registry);
+ * const resolved = uiSchema.resolveSchemaValues({ ppPerNode: 4 });
+ * ```
+ */
+export class UISchema {
+    constructor(schema, registry = {}) {
+        this.resolvedSchema = {};
+        this.schema = schema;
+        this.registry = registry;
+        this.resolveSchema();
+    }
+    resolveSchemaValues(schemaValues) {
+        return mapObjectDeep(this.resolvedSchema, (nestedObject) => {
+            const entries = Object.entries(nestedObject).map(([key, value]) => {
+                if (typeof value === "string") {
+                    const matched = value.match(/^\$val\.(.+)$/);
+                    if (matched) {
+                        if (schemaValues[matched[1]] !== undefined) {
+                            return [key, schemaValues[matched[1]]];
+                        }
+                        console.warn(`Schema ${this.schema.$id} variable ${matched[1]} not found`);
+                    }
+                }
+                return [key, value];
+            });
+            return Object.fromEntries(entries);
+        });
+    }
+    resolveSchema() {
+        if (this.schema.allOf) {
+            this.schema.allOf.forEach(({ $ref }) => {
+                if ($ref) {
+                    const schema = this.registry[$ref];
+                    if (schema) {
+                        this.resolvedSchema = {
+                            ...this.resolvedSchema,
+                            ...schema.properties,
+                        };
+                    }
+                }
+            });
+        }
+        if (Object.entries(this.resolvedSchema).length === 0) {
+            this.resolvedSchema = {
+                ...this.schema.properties,
+            };
+        }
+    }
+}
+/**
+ * Resolve a JSON schema by ID from the ESSE schema registry.
+ *
+ * @param schemaId - The ESSE schema identifier.
+ * @param removeRequired - If true, strips the `required` field from the result.
+ * @returns The resolved JSON schema, or an empty object if not found.
+ */
+export function resolveJsonSchema(schemaId, removeRequired = false) {
+    const schema = JSONSchemasInterface.getSchemaById(schemaId);
+    if (!schema) {
+        console.warn("Schema not found in ESSE:", schemaId);
+        return {};
+    }
+    if (removeRequired) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { required, ...optionalSchema } = schema;
+        return optionalSchema;
+    }
+    return schema;
+}
+/**
+ * Convenience factory: look up a UI schema by ID from a registry and wrap it
+ * in a {@link UISchema} instance.
+ *
+ * @param schemaId - Key into the `registry` map.
+ * @param registry - A map of schema IDs to raw JSON objects.
+ * @throws If the schema ID is not found in the registry.
+ */
+export function resolveUISchema(schemaId, registry) {
+    const schema = registry[schemaId];
+    if (!schema) {
+        throw new Error(`UI Schema is not found for ID: ${schemaId}`);
+    }
+    return new UISchema(schema, registry);
+}

--- a/dist/other/rjsf/widgets/PositionInfoPopover.styled.d.ts
+++ b/dist/other/rjsf/widgets/PositionInfoPopover.styled.d.ts
@@ -1,1 +1,4 @@
-export declare const PositionInfoPopover: StyledComponent<ComponentProps, SpecificComponentProps, JSXProps>;
+/// <reference types="react" />
+export declare const PositionInfoPopover: import("@emotion/styled").StyledComponent<import("@mui/system").BoxOwnProps<import("@mui/material/styles").Theme> & Omit<Omit<import("react").DetailedHTMLProps<import("react").HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "ref"> & {
+    ref?: ((instance: HTMLDivElement | null) => void) | import("react").RefObject<HTMLDivElement> | null | undefined;
+}, keyof import("@mui/system").BoxOwnProps<import("@mui/material/styles").Theme>> & import("@mui/system").MUIStyledCommonProps<import("@mui/material/styles").Theme>, {}, {}>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
                 "jszip": "^3.10.1",
                 "jszip-utils": "0.1.0",
                 "katex": "^0.16.21",
+                "lodash": "^4.17.21",
                 "notistack": "^3.0.1",
                 "prismjs": "^1.29.0",
                 "react-beautiful-dnd": "^13.1.1",
@@ -85,6 +86,7 @@
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
                 "react-json-view": "^1.21.3",
+                "tsx": "^4.23.0",
                 "underscore": "^1.13.7"
             },
             "engines": {
@@ -107,7 +109,6 @@
         },
         "node_modules/@ampproject/remapping": {
             "version": "2.3.0",
-            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
@@ -147,7 +148,6 @@
         },
         "node_modules/@babel/code-frame": {
             "version": "7.26.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.25.9",
@@ -160,7 +160,6 @@
         },
         "node_modules/@babel/compat-data": {
             "version": "7.26.5",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -168,7 +167,6 @@
         },
         "node_modules/@babel/core": {
             "version": "7.24.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
@@ -197,7 +195,6 @@
         },
         "node_modules/@babel/core/node_modules/convert-source-map": {
             "version": "2.0.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@babel/eslint-parser": {
@@ -218,7 +215,6 @@
         },
         "node_modules/@babel/generator": {
             "version": "7.26.5",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.26.5",
@@ -244,7 +240,6 @@
         },
         "node_modules/@babel/helper-compilation-targets": {
             "version": "7.26.5",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/compat-data": "^7.26.5",
@@ -334,7 +329,6 @@
         },
         "node_modules/@babel/helper-module-imports": {
             "version": "7.25.9",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/traverse": "^7.25.9",
@@ -346,7 +340,6 @@
         },
         "node_modules/@babel/helper-module-transforms": {
             "version": "7.26.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-module-imports": "^7.25.9",
@@ -425,7 +418,6 @@
         },
         "node_modules/@babel/helper-string-parser": {
             "version": "7.25.9",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -433,7 +425,6 @@
         },
         "node_modules/@babel/helper-validator-identifier": {
             "version": "7.25.9",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -441,7 +432,6 @@
         },
         "node_modules/@babel/helper-validator-option": {
             "version": "7.25.9",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -462,7 +452,6 @@
         },
         "node_modules/@babel/helpers": {
             "version": "7.26.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/template": "^7.25.9",
@@ -474,7 +463,6 @@
         },
         "node_modules/@babel/highlight": {
             "version": "7.25.9",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.25.9",
@@ -488,7 +476,6 @@
         },
         "node_modules/@babel/highlight/node_modules/ansi-styles": {
             "version": "3.2.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^1.9.0"
@@ -499,7 +486,6 @@
         },
         "node_modules/@babel/highlight/node_modules/chalk": {
             "version": "2.4.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^3.2.1",
@@ -512,7 +498,6 @@
         },
         "node_modules/@babel/highlight/node_modules/color-convert": {
             "version": "1.9.3",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "1.1.3"
@@ -520,12 +505,10 @@
         },
         "node_modules/@babel/highlight/node_modules/color-name": {
             "version": "1.1.3",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
             "version": "1.0.5",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.0"
@@ -533,7 +516,6 @@
         },
         "node_modules/@babel/highlight/node_modules/has-flag": {
             "version": "3.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=4"
@@ -541,7 +523,6 @@
         },
         "node_modules/@babel/highlight/node_modules/supports-color": {
             "version": "5.5.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-flag": "^3.0.0"
@@ -552,7 +533,6 @@
         },
         "node_modules/@babel/parser": {
             "version": "7.26.5",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.26.5"
@@ -1786,7 +1766,6 @@
         },
         "node_modules/@babel/template": {
             "version": "7.25.9",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.25.9",
@@ -1799,7 +1778,6 @@
         },
         "node_modules/@babel/traverse": {
             "version": "7.26.5",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.26.2",
@@ -1816,7 +1794,6 @@
         },
         "node_modules/@babel/types": {
             "version": "7.26.5",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.25.9",
@@ -1994,9 +1971,28 @@
                 "w3c-keyname": "^2.2.4"
             }
         },
+        "node_modules/@emotion/babel-plugin": {
+            "version": "11.13.5",
+            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+            "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.16.7",
+                "@babel/runtime": "^7.18.3",
+                "@emotion/hash": "^0.9.2",
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/serialize": "^1.3.3",
+                "babel-plugin-macros": "^3.1.0",
+                "convert-source-map": "^1.5.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-root": "^1.1.0",
+                "source-map": "^0.5.7",
+                "stylis": "4.2.0"
+            }
+        },
         "node_modules/@emotion/cache": {
             "version": "11.14.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@emotion/memoize": "^0.9.0",
@@ -2008,27 +2004,112 @@
         },
         "node_modules/@emotion/hash": {
             "version": "0.9.2",
-            "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@emotion/is-prop-valid": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+            "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@emotion/memoize": "^0.9.0"
+            }
         },
         "node_modules/@emotion/memoize": {
             "version": "0.9.0",
-            "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@emotion/react": {
+            "version": "11.14.0",
+            "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+            "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/runtime": "^7.18.3",
+                "@emotion/babel-plugin": "^11.13.5",
+                "@emotion/cache": "^11.14.0",
+                "@emotion/serialize": "^1.3.3",
+                "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+                "@emotion/utils": "^1.4.2",
+                "@emotion/weak-memoize": "^0.4.0",
+                "hoist-non-react-statics": "^3.3.1"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@emotion/serialize": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+            "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@emotion/hash": "^0.9.2",
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/unitless": "^0.10.0",
+                "@emotion/utils": "^1.4.2",
+                "csstype": "^3.0.2"
+            }
         },
         "node_modules/@emotion/sheet": {
             "version": "1.4.0",
-            "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@emotion/styled": {
+            "version": "11.14.1",
+            "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+            "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/runtime": "^7.18.3",
+                "@emotion/babel-plugin": "^11.13.5",
+                "@emotion/is-prop-valid": "^1.3.0",
+                "@emotion/serialize": "^1.3.3",
+                "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+                "@emotion/utils": "^1.4.2"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.0.0-rc.0",
+                "react": ">=16.8.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@emotion/unitless": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+            "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+            "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+            "license": "MIT",
+            "peer": true,
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
         },
         "node_modules/@emotion/utils": {
             "version": "1.4.2",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@emotion/weak-memoize": {
             "version": "0.4.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@es-joy/jsdoccomment": {
@@ -2042,6 +2123,448 @@
             },
             "engines": {
                 "node": "^12 || ^14 || ^16 || ^17"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+            "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+            "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+            "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+            "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+            "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+            "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+            "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+            "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+            "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+            "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+            "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+            "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+            "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+            "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+            "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+            "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+            "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+            "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+            "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+            "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+            "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+            "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+            "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -2082,7 +2605,6 @@
         },
         "node_modules/@eslint/eslintrc": {
             "version": "0.4.3",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ajv": "^6.12.4",
@@ -2101,7 +2623,6 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/ajv": {
             "version": "6.12.6",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -2116,7 +2637,6 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/argparse": {
             "version": "1.0.10",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "sprintf-js": "~1.0.2"
@@ -2124,7 +2644,6 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/globals": {
             "version": "13.24.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -2138,7 +2657,6 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/ignore": {
             "version": "4.0.6",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -2146,7 +2664,6 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
             "version": "3.14.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -2158,17 +2675,14 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
             "version": "0.4.1",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@eslint/eslintrc/node_modules/sprintf-js": {
             "version": "1.0.3",
-            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/@eslint/eslintrc/node_modules/type-fest": {
             "version": "0.20.2",
-            "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=10"
@@ -2212,7 +2726,6 @@
         },
         "node_modules/@floating-ui/core": {
             "version": "1.6.9",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/utils": "^0.2.9"
@@ -2220,7 +2733,6 @@
         },
         "node_modules/@floating-ui/dom": {
             "version": "1.6.13",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/core": "^1.6.0",
@@ -2229,7 +2741,6 @@
         },
         "node_modules/@floating-ui/react-dom": {
             "version": "2.1.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.0.0"
@@ -2241,12 +2752,10 @@
         },
         "node_modules/@floating-ui/utils": {
             "version": "0.2.9",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.5.0",
-            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@humanwhocodes/object-schema": "^1.2.0",
@@ -2259,7 +2768,6 @@
         },
         "node_modules/@humanwhocodes/object-schema": {
             "version": "1.2.1",
-            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/@istanbuljs/load-nyc-config": {
@@ -2368,7 +2876,6 @@
         },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.8",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/set-array": "^1.2.1",
@@ -2381,7 +2888,6 @@
         },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
@@ -2389,7 +2895,6 @@
         },
         "node_modules/@jridgewell/set-array": {
             "version": "1.2.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
@@ -2397,12 +2902,10 @@
         },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.25",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -2550,7 +3053,6 @@
         },
         "node_modules/@mui/base": {
             "version": "5.0.0-beta.40-0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
@@ -2581,7 +3083,6 @@
         },
         "node_modules/@mui/core-downloads-tracker": {
             "version": "5.16.14",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
@@ -2590,7 +3091,6 @@
         },
         "node_modules/@mui/icons-material": {
             "version": "5.16.14",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.23.9"
@@ -2655,7 +3155,6 @@
         },
         "node_modules/@mui/material": {
             "version": "5.16.14",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
@@ -2699,7 +3198,6 @@
         },
         "node_modules/@mui/private-theming": {
             "version": "5.16.14",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
@@ -2725,7 +3223,6 @@
         },
         "node_modules/@mui/styled-engine": {
             "version": "5.16.14",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
@@ -2796,7 +3293,6 @@
         },
         "node_modules/@mui/system": {
             "version": "5.16.14",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
@@ -2982,9 +3478,22 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@pkgr/core": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+            "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/pkgr"
+            }
+        },
         "node_modules/@popperjs/core": {
             "version": "2.11.8",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
@@ -3200,6 +3709,13 @@
             "dependencies": {
                 "undici-types": "~6.20.0"
             }
+        },
+        "node_modules/@types/parse-json": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+            "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/prettier": {
             "version": "2.7.3",
@@ -3560,7 +4076,6 @@
         },
         "node_modules/acorn": {
             "version": "7.4.1",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -3571,7 +4086,6 @@
         },
         "node_modules/acorn-jsx": {
             "version": "5.3.2",
-            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -3620,7 +4134,6 @@
         },
         "node_modules/ansi-colors": {
             "version": "4.1.3",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -3642,7 +4155,6 @@
         },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -3650,7 +4162,6 @@
         },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
@@ -3877,7 +4388,6 @@
         },
         "node_modules/astral-regex": {
             "version": "2.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -3911,6 +4421,22 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/babel-plugin-macros": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+            "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/runtime": "^7.12.5",
+                "cosmiconfig": "^7.0.0",
+                "resolve": "^1.19.0"
+            },
+            "engines": {
+                "node": ">=10",
+                "npm": ">=6"
             }
         },
         "node_modules/babel-plugin-polyfill-corejs2": {
@@ -3951,7 +4477,6 @@
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/base16": {
@@ -3972,7 +4497,6 @@
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -3997,7 +4521,6 @@
         },
         "node_modules/browserslist": {
             "version": "4.24.4",
-            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -4110,7 +4633,6 @@
         },
         "node_modules/callsites": {
             "version": "3.1.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -4126,7 +4648,6 @@
         },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001692",
-            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -4162,7 +4683,6 @@
         },
         "node_modules/chalk": {
             "version": "4.1.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.1.0",
@@ -4350,7 +4870,6 @@
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
@@ -4361,7 +4880,6 @@
         },
         "node_modules/color-name": {
             "version": "1.1.4",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/colorette": {
@@ -4417,7 +4935,6 @@
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/confusing-browser-globals": {
@@ -4427,7 +4944,6 @@
         },
         "node_modules/convert-source-map": {
             "version": "1.9.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/core-js": {
@@ -4462,6 +4978,23 @@
             "version": "1.0.3",
             "license": "MIT"
         },
+        "node_modules/cosmiconfig": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+            "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/parse-json": "^4.0.0",
+                "import-fresh": "^3.2.1",
+                "parse-json": "^5.0.0",
+                "path-type": "^4.0.0",
+                "yaml": "^1.10.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/crelt": {
             "version": "1.0.6",
             "license": "MIT"
@@ -4476,7 +5009,6 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -4592,7 +5124,6 @@
         },
         "node_modules/debug": {
             "version": "4.4.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -4632,7 +5163,6 @@
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/default-require-extensions": {
@@ -4689,6 +5219,17 @@
                 "node": ">=0.3.1"
             }
         },
+        "node_modules/diff-sequences": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
+            "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
         "node_modules/dir-glob": {
             "version": "3.0.1",
             "dev": true,
@@ -4702,7 +5243,6 @@
         },
         "node_modules/doctrine": {
             "version": "3.0.0",
-            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "esutils": "^2.0.2"
@@ -4743,7 +5283,6 @@
         },
         "node_modules/electron-to-chromium": {
             "version": "1.5.83",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
@@ -4753,7 +5292,6 @@
         },
         "node_modules/enquirer": {
             "version": "2.4.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-colors": "^4.1.1",
@@ -4761,6 +5299,16 @@
             },
             "engines": {
                 "node": ">=8.6"
+            }
+        },
+        "node_modules/error-ex": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+            "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "is-arrayish": "^0.2.1"
             }
         },
         "node_modules/es-abstract": {
@@ -4971,9 +5519,50 @@
                 "es6-symbol": "^3.1.1"
             }
         },
+        "node_modules/esbuild": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+            "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.28.1",
+                "@esbuild/android-arm": "0.28.1",
+                "@esbuild/android-arm64": "0.28.1",
+                "@esbuild/android-x64": "0.28.1",
+                "@esbuild/darwin-arm64": "0.28.1",
+                "@esbuild/darwin-x64": "0.28.1",
+                "@esbuild/freebsd-arm64": "0.28.1",
+                "@esbuild/freebsd-x64": "0.28.1",
+                "@esbuild/linux-arm": "0.28.1",
+                "@esbuild/linux-arm64": "0.28.1",
+                "@esbuild/linux-ia32": "0.28.1",
+                "@esbuild/linux-loong64": "0.28.1",
+                "@esbuild/linux-mips64el": "0.28.1",
+                "@esbuild/linux-ppc64": "0.28.1",
+                "@esbuild/linux-riscv64": "0.28.1",
+                "@esbuild/linux-s390x": "0.28.1",
+                "@esbuild/linux-x64": "0.28.1",
+                "@esbuild/netbsd-arm64": "0.28.1",
+                "@esbuild/netbsd-x64": "0.28.1",
+                "@esbuild/openbsd-arm64": "0.28.1",
+                "@esbuild/openbsd-x64": "0.28.1",
+                "@esbuild/openharmony-arm64": "0.28.1",
+                "@esbuild/sunos-x64": "0.28.1",
+                "@esbuild/win32-arm64": "0.28.1",
+                "@esbuild/win32-ia32": "0.28.1",
+                "@esbuild/win32-x64": "0.28.1"
+            }
+        },
         "node_modules/escalade": {
             "version": "3.2.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -4986,7 +5575,6 @@
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -4997,7 +5585,6 @@
         },
         "node_modules/eslint": {
             "version": "7.32.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "7.12.11",
@@ -5049,6 +5636,37 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint-compat-utils": {
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.6.5.tgz",
+            "integrity": "sha512-vAUHYzue4YAa2hNACjB8HvUQj5yehAZgiClyFVVom9cP8z5NSFq3PwB/TtJslN2zAMgRX6FCFCjYBbQh71g5RQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "eslint": ">=6.0.0"
+            }
+        },
+        "node_modules/eslint-compat-utils/node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/eslint-config-airbnb": {
@@ -5140,6 +5758,29 @@
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.1"
+            }
+        },
+        "node_modules/eslint-json-compat-utils": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/eslint-json-compat-utils/-/eslint-json-compat-utils-0.2.3.tgz",
+            "integrity": "sha512-RbBmDFyu7FqnjE8F0ZxPNzx5UaptdeS9Uu50r7A+D7s/+FCX+ybiyViYEgFUaFIFqSWJgZRTpL5d8Kanxxl2lQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "esquery": "^1.6.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "eslint": "*",
+                "jsonc-eslint-parser": "^2.4.0 || ^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@eslint/json": {
+                    "optional": true
+                }
             }
         },
         "node_modules/eslint-module-utils": {
@@ -5249,6 +5890,81 @@
                 "node": ">=10"
             }
         },
+        "node_modules/eslint-plugin-jsonc": {
+            "version": "2.21.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.21.1.tgz",
+            "integrity": "sha512-dbNR5iEnQeORwsK2WZzr3QaMtFCY3kKJVMRHPzUpKzMhmVy2zIpVgFDpX8MNoIdoqz6KCpCfOJavhfiSbZbN+w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.5.1",
+                "diff-sequences": "^27.5.1",
+                "eslint-compat-utils": "^0.6.4",
+                "eslint-json-compat-utils": "^0.2.1",
+                "espree": "^9.6.1 || ^10.3.0",
+                "graphemer": "^1.4.0",
+                "jsonc-eslint-parser": "^2.4.0",
+                "natural-compare": "^1.4.0",
+                "synckit": "^0.6.2 || ^0.7.3 || ^0.11.5"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ota-meshi"
+            },
+            "peerDependencies": {
+                "eslint": ">=6.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-jsonc/node_modules/acorn": {
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/eslint-plugin-jsonc/node_modules/eslint-visitor-keys": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint-plugin-jsonc/node_modules/espree": {
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "peer": true,
+            "dependencies": {
+                "acorn": "^8.15.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^4.2.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
         "node_modules/eslint-plugin-jsx-a11y": {
             "version": "6.10.2",
             "dev": true,
@@ -5342,6 +6058,20 @@
                 "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
             }
         },
+        "node_modules/eslint-plugin-react-hooks": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
+            "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+            }
+        },
         "node_modules/eslint-plugin-react/node_modules/doctrine": {
             "version": "2.1.0",
             "dev": true,
@@ -5397,7 +6127,6 @@
         },
         "node_modules/eslint-utils": {
             "version": "2.1.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "eslint-visitor-keys": "^1.1.0"
@@ -5411,7 +6140,6 @@
         },
         "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
             "version": "1.3.0",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=4"
@@ -5426,7 +6154,6 @@
         },
         "node_modules/eslint/node_modules/@babel/code-frame": {
             "version": "7.12.11",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/highlight": "^7.10.4"
@@ -5434,7 +6161,6 @@
         },
         "node_modules/eslint/node_modules/ajv": {
             "version": "6.12.6",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -5449,7 +6175,6 @@
         },
         "node_modules/eslint/node_modules/argparse": {
             "version": "1.0.10",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "sprintf-js": "~1.0.2"
@@ -5457,7 +6182,6 @@
         },
         "node_modules/eslint/node_modules/globals": {
             "version": "13.24.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -5471,7 +6195,6 @@
         },
         "node_modules/eslint/node_modules/ignore": {
             "version": "4.0.6",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -5479,7 +6202,6 @@
         },
         "node_modules/eslint/node_modules/js-yaml": {
             "version": "3.14.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -5491,12 +6213,10 @@
         },
         "node_modules/eslint/node_modules/json-schema-traverse": {
             "version": "0.4.1",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/semver": {
             "version": "7.6.3",
-            "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -5507,12 +6227,10 @@
         },
         "node_modules/eslint/node_modules/sprintf-js": {
             "version": "1.0.3",
-            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/eslint/node_modules/type-fest": {
             "version": "0.20.2",
-            "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=10"
@@ -5537,7 +6255,6 @@
         },
         "node_modules/espree": {
             "version": "7.3.1",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "acorn": "^7.4.0",
@@ -5550,7 +6267,6 @@
         },
         "node_modules/espree/node_modules/eslint-visitor-keys": {
             "version": "1.3.0",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=4"
@@ -5558,7 +6274,6 @@
         },
         "node_modules/esprima": {
             "version": "4.0.1",
-            "dev": true,
             "license": "BSD-2-Clause",
             "bin": {
                 "esparse": "bin/esparse.js",
@@ -5570,7 +6285,6 @@
         },
         "node_modules/esquery": {
             "version": "1.6.0",
-            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "estraverse": "^5.1.0"
@@ -5598,7 +6312,6 @@
         },
         "node_modules/esutils": {
             "version": "2.0.3",
-            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -5669,12 +6382,10 @@
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-uri": {
@@ -5728,7 +6439,6 @@
         },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "flat-cache": "^3.0.4"
@@ -5761,6 +6471,13 @@
                 "node": ">=6"
             }
         },
+        "node_modules/find-root": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/find-up": {
             "version": "5.0.0",
             "dev": true,
@@ -5786,7 +6503,6 @@
         },
         "node_modules/flat-cache": {
             "version": "3.2.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "flatted": "^3.2.9",
@@ -5799,7 +6515,6 @@
         },
         "node_modules/flatted": {
             "version": "3.3.2",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/flux": {
@@ -5868,7 +6583,6 @@
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/fscreen": {
@@ -5889,7 +6603,6 @@
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -5916,7 +6629,6 @@
         },
         "node_modules/functional-red-black-tree": {
             "version": "1.0.1",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/functions-have-names": {
@@ -5929,7 +6641,6 @@
         },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -6034,7 +6745,6 @@
         },
         "node_modules/glob": {
             "version": "7.2.3",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -6053,7 +6763,6 @@
         },
         "node_modules/glob-parent": {
             "version": "5.1.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.1"
@@ -6082,7 +6791,6 @@
         },
         "node_modules/globals": {
             "version": "11.12.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=4"
@@ -6179,7 +6887,6 @@
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -6260,7 +6967,6 @@
         },
         "node_modules/hasown": {
             "version": "2.0.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -6334,7 +7040,6 @@
         },
         "node_modules/import-fresh": {
             "version": "3.3.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "parent-module": "^1.0.0",
@@ -6349,7 +7054,6 @@
         },
         "node_modules/imurmurhash": {
             "version": "0.1.4",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.19"
@@ -6365,7 +7069,6 @@
         },
         "node_modules/inflight": {
             "version": "1.0.6",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "once": "^1.3.0",
@@ -6404,6 +7107,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/is-async-function": {
             "version": "2.1.0",
@@ -6480,7 +7190,6 @@
         },
         "node_modules/is-core-module": {
             "version": "2.16.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "hasown": "^2.0.2"
@@ -6525,7 +7234,6 @@
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -6575,7 +7283,6 @@
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
@@ -6856,7 +7563,6 @@
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/isobject": {
@@ -7044,7 +7750,6 @@
         },
         "node_modules/jsesc": {
             "version": "3.1.0",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "jsesc": "bin/jsesc"
@@ -7055,8 +7760,14 @@
         },
         "node_modules/json-buffer": {
             "version": "3.0.1",
-            "dev": true,
             "license": "MIT"
+        },
+        "node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/json-schema": {
             "version": "0.4.0",
@@ -7133,18 +7844,97 @@
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/json5": {
             "version": "2.2.3",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "json5": "lib/cli.js"
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/jsonc-eslint-parser": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.2.tgz",
+            "integrity": "sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "acorn": "^8.5.0",
+                "eslint-visitor-keys": "^3.0.0",
+                "espree": "^9.0.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ota-meshi"
+            }
+        },
+        "node_modules/jsonc-eslint-parser/node_modules/acorn": {
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/jsonc-eslint-parser/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/jsonc-eslint-parser/node_modules/espree": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "peer": true,
+            "dependencies": {
+                "acorn": "^8.9.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^3.4.1"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/jsonc-eslint-parser/node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/jsonpointer": {
@@ -7287,7 +8077,6 @@
         },
         "node_modules/keyv": {
             "version": "4.5.4",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "json-buffer": "3.0.1"
@@ -7319,7 +8108,6 @@
         },
         "node_modules/levn": {
             "version": "0.4.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "prelude-ls": "^1.2.1",
@@ -7343,6 +8131,13 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/lines-and-columns": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lint-staged": {
             "version": "12.5.0",
@@ -7517,12 +8312,10 @@
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.truncate": {
             "version": "4.4.2",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/log-symbols": {
@@ -7632,7 +8425,6 @@
         },
         "node_modules/lru-cache": {
             "version": "5.1.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^3.0.2"
@@ -7782,7 +8574,6 @@
         },
         "node_modules/minimatch": {
             "version": "3.1.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -7980,7 +8771,7 @@
         },
         "node_modules/moment": {
             "version": "2.30.1",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": "*"
@@ -7988,7 +8779,6 @@
         },
         "node_modules/ms": {
             "version": "2.1.3",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/mz": {
@@ -8003,7 +8793,6 @@
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/natural-compare-lite": {
@@ -8048,7 +8837,6 @@
         },
         "node_modules/node-releases": {
             "version": "2.0.19",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/normalize-path": {
@@ -8471,7 +9259,6 @@
         },
         "node_modules/once": {
             "version": "1.4.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
@@ -8493,7 +9280,6 @@
         },
         "node_modules/optionator": {
             "version": "0.9.4",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "deep-is": "^0.1.3",
@@ -8597,13 +9383,31 @@
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "callsites": "^3.0.0"
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/parse-json": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/path-exists": {
@@ -8616,7 +9420,6 @@
         },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -8624,7 +9427,6 @@
         },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -8632,12 +9434,10 @@
         },
         "node_modules/path-parse": {
             "version": "1.0.7",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/path-type": {
             "version": "4.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -8653,7 +9453,6 @@
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/picomatch": {
@@ -8771,7 +9570,6 @@
         },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8.0"
@@ -8826,7 +9624,6 @@
         },
         "node_modules/progress": {
             "version": "2.0.3",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
@@ -8922,7 +9719,6 @@
         },
         "node_modules/punycode": {
             "version": "2.3.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -8966,7 +9762,6 @@
         },
         "node_modules/react": {
             "version": "17.0.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0",
@@ -9006,7 +9801,6 @@
         },
         "node_modules/react-dom": {
             "version": "17.0.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0",
@@ -9279,7 +10073,6 @@
         },
         "node_modules/regexpp": {
             "version": "3.2.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -9380,7 +10173,6 @@
         },
         "node_modules/resolve": {
             "version": "1.22.10",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-core-module": "^2.16.0",
@@ -9399,7 +10191,6 @@
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=4"
@@ -9441,7 +10232,6 @@
         },
         "node_modules/rimraf": {
             "version": "3.0.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "glob": "^7.1.3"
@@ -9552,7 +10342,6 @@
         },
         "node_modules/scheduler": {
             "version": "0.20.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0",
@@ -9644,7 +10433,6 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
@@ -9655,7 +10443,6 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -9783,7 +10570,6 @@
         },
         "node_modules/source-map": {
             "version": "0.5.7",
-            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -10018,7 +10804,6 @@
         },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -10045,7 +10830,6 @@
         },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -10060,12 +10844,10 @@
         },
         "node_modules/stylis": {
             "version": "4.2.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
@@ -10076,7 +10858,6 @@
         },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -10085,9 +10866,25 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/synckit": {
+            "version": "0.11.13",
+            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+            "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@pkgr/core": "^0.3.6"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/synckit"
+            }
+        },
         "node_modules/table": {
             "version": "6.9.0",
-            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "ajv": "^8.0.1",
@@ -10102,12 +10899,10 @@
         },
         "node_modules/table/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/table/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -10115,7 +10910,6 @@
         },
         "node_modules/table/node_modules/slice-ansi": {
             "version": "4.0.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
@@ -10131,7 +10925,6 @@
         },
         "node_modules/table/node_modules/string-width": {
             "version": "4.2.3",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
@@ -10157,7 +10950,6 @@
         },
         "node_modules/text-table": {
             "version": "0.2.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/thenify": {
@@ -10296,6 +11088,25 @@
             "dev": true,
             "license": "0BSD"
         },
+        "node_modules/tsx": {
+            "version": "4.23.0",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+            "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "~0.28.0"
+            },
+            "bin": {
+                "tsx": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            }
+        },
         "node_modules/type": {
             "version": "2.7.3",
             "dev": true,
@@ -10303,7 +11114,6 @@
         },
         "node_modules/type-check": {
             "version": "0.4.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "prelude-ls": "^1.2.1"
@@ -10549,7 +11359,6 @@
         },
         "node_modules/update-browserslist-db": {
             "version": "1.1.2",
-            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -10578,7 +11387,6 @@
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
@@ -10647,7 +11455,6 @@
         },
         "node_modules/v8-compile-cache": {
             "version": "2.4.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/valid-url": {
@@ -10697,7 +11504,6 @@
         },
         "node_modules/which": {
             "version": "2.0.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
@@ -10801,7 +11607,6 @@
         },
         "node_modules/word-wrap": {
             "version": "1.2.5",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -10856,7 +11661,6 @@
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/write-file-atomic": {
@@ -10880,12 +11684,10 @@
         },
         "node_modules/yallist": {
             "version": "3.1.1",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/yaml": {
             "version": "1.10.2",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">= 6"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
         "underscore": "^1.8.3"
     },
     "dependencies": {
-        "lodash": "^4.17.21",
         "@babel/eslint-parser": "^7.26.5",
         "@codemirror/autocomplete": "^6.18.4",
         "@codemirror/lang-javascript": "^6.2.2",
@@ -69,6 +68,7 @@
         "jszip": "^3.10.1",
         "jszip-utils": "0.1.0",
         "katex": "^0.16.21",
+        "lodash": "^4.17.21",
         "notistack": "^3.0.1",
         "prismjs": "^1.29.0",
         "react-beautiful-dnd": "^13.1.1",
@@ -118,6 +118,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-json-view": "^1.21.3",
+        "tsx": "^4.23.0",
         "underscore": "^1.13.7"
     },
     "engines": {

--- a/src/mui/components/popover/info-popover/InfoPopoverWithDocumentation.tsx
+++ b/src/mui/components/popover/info-popover/InfoPopoverWithDocumentation.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import InfoPopover from "./InfoPopover";
 
 export interface InfoPopoverWithDocumentationProps {

--- a/src/mui/components/tabs/TabsMenu.tsx
+++ b/src/mui/components/tabs/TabsMenu.tsx
@@ -1,15 +1,14 @@
 import FormControl from "@mui/material/FormControl";
-import { alpha, styled, useTheme } from "@mui/material/styles";
 import type { SxProps, Theme } from "@mui/material/styles";
+import { alpha, styled, useTheme } from "@mui/material/styles";
 import Tab from "@mui/material/Tab";
-import Tabs from "@mui/material/Tabs";
 import type { TabsProps } from "@mui/material/Tabs";
+import Tabs from "@mui/material/Tabs";
 import TextField from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
 import React, { useEffect } from "react";
 
 import IconByName from "../icon/IconByName";
-
 import type { TabItem } from "./types";
 
 const TabsMenuContainer = styled("div")(({ theme }: { theme?: Theme }) => ({

--- a/src/other/rjsf/schemaUtils.ts
+++ b/src/other/rjsf/schemaUtils.ts
@@ -1,0 +1,147 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import JSONSchemasInterface from "@mat3ra/esse/dist/js/esse/JSONSchemasInterface";
+import type { JSONSchema7 } from "json-schema";
+
+/**
+ * Generic deep-map for plain objects. Recursively applies `mapValue` to each
+ * plain-object node. If `mapValue` returns a truthy value, that value replaces
+ * the node (its children are still traversed). Non-plain objects, primitives,
+ * and arrays of primitives are returned unchanged.
+ *
+ * NOTE: A copy of this function also lives in @mat3ra/utils (object module).
+ * We inline it here to avoid adding @mat3ra/utils as a dependency of cove.
+ */
+function mapObjectDeep(object: any, mapValue: (node: any) => any | undefined): any {
+    if (typeof object !== "object" || object === null) {
+        return object;
+    }
+
+    if (Array.isArray(object)) {
+        return object.map((innerValue) => mapObjectDeep(innerValue, mapValue));
+    }
+
+    if (object.constructor !== Object) {
+        return object;
+    }
+
+    const mappedObject = mapValue(object) || object;
+
+    const entries = Object.entries(mappedObject).map(([key, value]) => {
+        return [key, mapObjectDeep(value, mapValue)];
+    });
+
+    return Object.fromEntries(entries);
+}
+
+/**
+ * A registry type mapping schema IDs to their raw JSON content.
+ * Consumers provide this when constructing a UISchema so the schema
+ * resolution stays decoupled from any particular set of UI schemas.
+ */
+export type UISchemaRegistry = Record<string, any>;
+
+/**
+ * Wraps a raw UI schema object with `$val.*` variable resolution
+ * and `allOf.$ref` composition support.
+ *
+ * @example
+ * ```ts
+ * const registry: UISchemaRegistry = { "job/compute/base": baseSchema };
+ * const uiSchema = new UISchema(registry["job/compute/base"], registry);
+ * const resolved = uiSchema.resolveSchemaValues({ ppPerNode: 4 });
+ * ```
+ */
+export class UISchema {
+    private schema: any;
+
+    private resolvedSchema: any = {};
+
+    private registry: UISchemaRegistry;
+
+    constructor(schema: any, registry: UISchemaRegistry = {}) {
+        this.schema = schema;
+        this.registry = registry;
+        this.resolveSchema();
+    }
+
+    resolveSchemaValues(schemaValues: any) {
+        return mapObjectDeep(this.resolvedSchema, (nestedObject: any) => {
+            const entries = Object.entries(nestedObject).map(([key, value]) => {
+                if (typeof value === "string") {
+                    const matched = value.match(/^\$val\.(.+)$/);
+
+                    if (matched) {
+                        if (schemaValues[matched[1]] !== undefined) {
+                            return [key, schemaValues[matched[1]]];
+                        }
+
+                        console.warn(`Schema ${this.schema.$id} variable ${matched[1]} not found`);
+                    }
+                }
+
+                return [key, value];
+            });
+
+            return Object.fromEntries(entries);
+        });
+    }
+
+    resolveSchema() {
+        if (this.schema.allOf) {
+            this.schema.allOf.forEach(({ $ref }: any) => {
+                if ($ref) {
+                    const schema = this.registry[$ref];
+                    if (schema) {
+                        this.resolvedSchema = {
+                            ...this.resolvedSchema,
+                            ...schema.properties,
+                        };
+                    }
+                }
+            });
+        }
+
+        if (Object.entries(this.resolvedSchema).length === 0) {
+            this.resolvedSchema = {
+                ...this.schema.properties,
+            };
+        }
+    }
+}
+
+/**
+ * Resolve a JSON schema by ID from the ESSE schema registry.
+ *
+ * @param schemaId - The ESSE schema identifier.
+ * @param removeRequired - If true, strips the `required` field from the result.
+ * @returns The resolved JSON schema, or an empty object if not found.
+ */
+export function resolveJsonSchema(schemaId: string, removeRequired = false): JSONSchema7 {
+    const schema = JSONSchemasInterface.getSchemaById(schemaId);
+    if (!schema) {
+        console.warn("Schema not found in ESSE:", schemaId);
+        return {} as JSONSchema7;
+    }
+    if (removeRequired) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { required, ...optionalSchema } = schema as any;
+        return optionalSchema as JSONSchema7;
+    }
+    return schema as JSONSchema7;
+}
+
+/**
+ * Convenience factory: look up a UI schema by ID from a registry and wrap it
+ * in a {@link UISchema} instance.
+ *
+ * @param schemaId - Key into the `registry` map.
+ * @param registry - A map of schema IDs to raw JSON objects.
+ * @throws If the schema ID is not found in the registry.
+ */
+export function resolveUISchema(schemaId: string, registry: UISchemaRegistry): UISchema {
+    const schema = registry[schemaId];
+    if (!schema) {
+        throw new Error(`UI Schema is not found for ID: ${schemaId}`);
+    }
+    return new UISchema(schema, registry);
+}

--- a/tests/schemaUtils.tests.ts
+++ b/tests/schemaUtils.tests.ts
@@ -1,0 +1,78 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { UISchema, resolveUISchema } from "../src/other/rjsf/schemaUtils";
+import type { UISchemaRegistry } from "../src/other/rjsf/schemaUtils";
+
+describe("UISchema", () => {
+    it("resolves properties from a flat schema", () => {
+        const schema = {
+            properties: {
+                ppn: { "ui:widget": "updown", "ui:title": "PPN" },
+            },
+        };
+        const uiSchema = new UISchema(schema);
+        const resolved = uiSchema.resolveSchemaValues({});
+        assert.deepStrictEqual(resolved, {
+            ppn: { "ui:widget": "updown", "ui:title": "PPN" },
+        });
+    });
+
+    it("resolves $val.* variables from schemaValues", () => {
+        const schema = {
+            properties: {
+                ppn: { "ui:widget": "updown", "ui:options": { default: "$val.defaultPpn" } },
+            },
+        };
+        const uiSchema = new UISchema(schema);
+        const resolved = uiSchema.resolveSchemaValues({ defaultPpn: 4 });
+        assert.deepStrictEqual(resolved, {
+            ppn: { "ui:widget": "updown", "ui:options": { default: 4 } },
+        });
+    });
+
+    it("composes allOf.$ref schemas from registry", () => {
+        const registry: UISchemaRegistry = {
+            "base": {
+                properties: {
+                    ppn: { "ui:widget": "updown" },
+                },
+            },
+            "extra": {
+                properties: {
+                    queue: { "ui:widget": "select" },
+                },
+            },
+        };
+        const schema = {
+            allOf: [{ $ref: "base" }, { $ref: "extra" }],
+        };
+        const uiSchema = new UISchema(schema, registry);
+        const resolved = uiSchema.resolveSchemaValues({});
+        assert.deepStrictEqual(resolved, {
+            ppn: { "ui:widget": "updown" },
+            queue: { "ui:widget": "select" },
+        });
+    });
+});
+
+describe("resolveUISchema", () => {
+    it("returns a UISchema instance for a known ID", () => {
+        const registry: UISchemaRegistry = {
+            "job/compute/base": {
+                properties: {
+                    ppn: { "ui:widget": "updown" },
+                },
+            },
+        };
+        const uiSchema = resolveUISchema("job/compute/base", registry);
+        assert.ok(uiSchema instanceof UISchema);
+    });
+
+    it("throws for unknown schema ID", () => {
+        assert.throws(
+            () => resolveUISchema("nonexistent", {}),
+            { message: "UI Schema is not found for ID: nonexistent" },
+        );
+    });
+});


### PR DESCRIPTION
Adds `UISchema`, `resolveJsonSchema`, and `resolveUISchema` to `@exabyte-io/cove.js/dist/other/rjsf/schemaUtils`.

Migrated from `ive/src/utils/schemas.ts`. The `UISchema` class is made generic by accepting a registry parameter, decoupling it from any specific set of UI schemas.

Importable as:
```ts
import { UISchema, resolveJsonSchema, resolveUISchema } from '@exabyte-io/cove.js/dist/other/rjsf/schemaUtils';
```