### PR TITLE
fix: add account-card-name/account-card-type class hooks to AccountCard

### DIFF
--- a/dist/mui-composed/components/account/AccountCard.js
+++ b/dist/mui-composed/components/account/AccountCard.js
@@ -17,7 +17,7 @@ export function AccountCard({ account, onClick, subtitle, size = "medium" }) {
                 fontSize: currentSize.avatar / 2.5,
             } }, !avatarUrl ? name.substring(0, 1).toUpperCase() : undefined),
         React.createElement(Stack, { spacing: 0.2, overflow: "hidden" },
-            React.createElement(Typography, { variant: currentSize.name, noWrap: true, fontWeight: "bold" }, name),
-            subtitle && (React.createElement(Typography, { variant: currentSize.type, color: "text.secondary", noWrap: true }, subtitle)))));
+            React.createElement(Typography, { variant: currentSize.name, noWrap: true, fontWeight: "bold", className: "account-card-name" }, name),
+            subtitle && (React.createElement(Typography, { variant: currentSize.type, color: "text.secondary", noWrap: true, className: "account-card-type" }, subtitle)))));
 }
 export default AccountCard;

--- a/src/mui-composed/components/account/AccountCard.tsx
+++ b/src/mui-composed/components/account/AccountCard.tsx
@@ -42,11 +42,19 @@ export function AccountCard({ account, onClick, subtitle, size = "medium" }: Acc
                 {!avatarUrl ? name.substring(0, 1).toUpperCase() : undefined}
             </Avatar>
             <Stack spacing={0.2} overflow="hidden">
-                <Typography variant={currentSize.name} noWrap fontWeight="bold">
+                <Typography
+                    variant={currentSize.name}
+                    noWrap
+                    fontWeight="bold"
+                    className="account-card-name">
                     {name}
                 </Typography>
                 {subtitle && (
-                    <Typography variant={currentSize.type} color="text.secondary" noWrap>
+                    <Typography
+                        variant={currentSize.type}
+                        color="text.secondary"
+                        noWrap
+                        className="account-card-type">
                         {subtitle}
                     </Typography>
                 )}


### PR DESCRIPTION
Restores the `account-card-name` / `account-card-type` class names on `AccountCard`'s name and subtitle `Typography` elements. Downstream selectors (web-app Cypress account-switch/org-member specs, and any consumer styling) rely on these hooks; they were lost in the MUI-composed rewrite.

web-app currently carries this identical change as a `patch-package` patch (`patches/@exabyte-io+cove.js+2026.7.9-1.patch`) pending this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)