### PR TITLE
chore: migrate package to @mat3ra scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ cove houses entity definitions for use in the Mat3ra platform.
 For usage within a javascript project:
 
 ```bash
-npm install @exabyte-io/cove.js
+npm install @mat3ra/cove.js
 ```
 
 For development:
 
 ```bash
-git clone https://github.com/Exabyte-io/cove.js.git
+git clone https://github.com/mat3ra/cove.js.git
 cd cove.js
 npm install
 npm run transpile
@@ -25,8 +25,8 @@ npm run transpile
 
 How to link cove.js to host app:
 ```bash
-rm -rf {PATH}/exabyte-stack/web-app/src/application/node_modules/@exabyte-io/cove.js/dist
-ln -s "$(pwd)/dist/" /{ABSOLUTE_PATH}/exabyte-stack/web-app/src/application/node_modules/@exabyte-io/cove.js
+rm -rf {PATH}/exabyte-stack/web-app/src/application/node_modules/@mat3ra/cove.js/dist
+ln -s "$(pwd)/dist/" /{ABSOLUTE_PATH}/exabyte-stack/web-app/src/application/node_modules/@mat3ra/cove.js
 restart host app (web-app, wave etc.)
 ```
 
@@ -35,7 +35,7 @@ another approach is to access cove from repo
 ```bash
 push your branch
 replace cove.js version with url in package.json
-"@exabyte-io/cove.js": "https://github.com/Exabyte-io/cove.js#cc48da9652840eb0f7d8854e02cb690484e6fab1",
+"@mat3ra/cove.js": "https://github.com/mat3ra/cove.js#cc48da9652840eb0f7d8854e02cb690484e6fab1",
 ```
 make sure to install appropriate versions of peerDependencies from cove.js to host app
 
@@ -49,7 +49,7 @@ https://legacy.reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-rea
 Typescript and all necessary type dependencies must be present in dependency section of package.json in order
 to transpile files and generate type definitions during package installation on postinstall command.
 It is necessary for testing arbitrary branches for example as dependency
-git+https://github.com/Exabyte-io/cove.js.git#b7604da7717232ac38a6372fea603f0b04645ade in web-app.
+git+https://github.com/mat3ra/cove.js.git#b7604da7717232ac38a6372fea603f0b04645ade in web-app.
 
 ### Contribution
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@exabyte-io/cove.js",
+    "name": "@mat3ra/cove.js",
     "version": "0.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "@exabyte-io/cove.js",
+            "name": "@mat3ra/cove.js",
             "version": "0.0.0",
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@exabyte-io/cove.js",
+    "name": "@mat3ra/cove.js",
     "version": "0.0.0",
     "description": "Cove.js - reusable components",
     "scripts": {
@@ -12,7 +12,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/Exabyte-io/cove.js.git"
+        "url": "https://github.com/mat3ra/cove.js.git"
     },
     "main": "dist/index.js",
     "files": [
@@ -22,10 +22,10 @@
     ],
     "author": "Exabyte Inc.",
     "bugs": {
-        "url": "https://github.com/Exabyte-io/cove.js/issues"
+        "url": "https://github.com/mat3ra/cove.js/issues"
     },
     "license": "Apache-2.0",
-    "homepage": "https://github.com/Exabyte-io/cove.js",
+    "homepage": "https://github.com/mat3ra/cove.js",
     "peerDependencies": {
         "@mat3ra/code": "*",
         "@mat3ra/esse": "*",


### PR DESCRIPTION
Renames the npm package `@exabyte-io/cove.js` → `@mat3ra/cove.js` (name, repository/bugs/homepage URLs, README, lockfile). No code changes; `dist/` has no self-references, so no rebuild is needed.

On merge, CI publishes the first `@mat3ra/cove.js` release. Existing `@exabyte-io/cove.js` versions stay on npm for older branches. All 10 consumer packages (ave, ive, jove, job-designer, materials-designer, move, prove, wave.js, workflow-designer, wove) and web-app migrate in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)