### PR TITLE
feat: add GitHub Pages component gallery

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -60,3 +60,29 @@ jobs:
           npm-token: ${{ secrets.NPM_TOKEN }}
           github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
+
+  deploy-bundle:
+    needs: [publish-js-package]
+    runs-on: ubuntu-latest
+    if: (github.repository != 'Exabyte-io/template-definitions') && (github.ref_name == 'main')
+
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v4
+
+      - name: Setup NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: https://registry.npmjs.org
+
+      - name: Build component gallery
+        shell: bash -l {0}
+        run: |
+          npm install --legacy-peer-deps && npm run build:standalone
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ cove houses entity definitions for use in the Mat3ra platform.
 For usage within a javascript project:
 
 ```bash
-npm install @exabyte-io/cove.js
+npm install @mat3ra/cove.js
 ```
 
 For development:
 
 ```bash
-git clone https://github.com/Exabyte-io/cove.js.git
+git clone https://github.com/mat3ra/cove.js.git
 cd cove.js
 npm install
 npm run transpile
@@ -25,8 +25,8 @@ npm run transpile
 
 How to link cove.js to host app:
 ```bash
-rm -rf {PATH}/exabyte-stack/web-app/src/application/node_modules/@exabyte-io/cove.js/dist
-ln -s "$(pwd)/dist/" /{ABSOLUTE_PATH}/exabyte-stack/web-app/src/application/node_modules/@exabyte-io/cove.js
+rm -rf {PATH}/exabyte-stack/web-app/src/application/node_modules/@mat3ra/cove.js/dist
+ln -s "$(pwd)/dist/" /{ABSOLUTE_PATH}/exabyte-stack/web-app/src/application/node_modules/@mat3ra/cove.js
 restart host app (web-app, wave etc.)
 ```
 
@@ -35,7 +35,7 @@ another approach is to access cove from repo
 ```bash
 push your branch
 replace cove.js version with url in package.json
-"@exabyte-io/cove.js": "https://github.com/Exabyte-io/cove.js#cc48da9652840eb0f7d8854e02cb690484e6fab1",
+"@mat3ra/cove.js": "https://github.com/mat3ra/cove.js#cc48da9652840eb0f7d8854e02cb690484e6fab1",
 ```
 make sure to install appropriate versions of peerDependencies from cove.js to host app
 
@@ -49,7 +49,7 @@ https://legacy.reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-rea
 Typescript and all necessary type dependencies must be present in dependency section of package.json in order
 to transpile files and generate type definitions during package installation on postinstall command.
 It is necessary for testing arbitrary branches for example as dependency
-git+https://github.com/Exabyte-io/cove.js.git#b7604da7717232ac38a6372fea603f0b04645ade in web-app.
+git+https://github.com/mat3ra/cove.js.git#b7604da7717232ac38a6372fea603f0b04645ade in web-app.
 
 ### Contribution
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>cove.js — Component Gallery</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script type="module" src="/src/standalone/index.tsx"></script>
+    </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,8 @@
                 "underscore.string": "^3.3.6"
             },
             "devDependencies": {
+                "@emotion/react": "^11.14.0",
+                "@emotion/styled": "^11.14.1",
                 "@exabyte-io/eslint-config": "2025.5.13-0",
                 "@mat3ra/code": "2024.10.4-0",
                 "@mat3ra/esse": "2024.12.19-1",
@@ -61,6 +63,7 @@
                 "@types/underscore": "^1.13.0",
                 "@typescript-eslint/eslint-plugin": "^5.62.0",
                 "@typescript-eslint/parser": "^5.62.0",
+                "@vitejs/plugin-react": "^4.3.0",
                 "chai": "^4.5.0",
                 "classnames": "^2.5.1",
                 "eslint": "^7.32.0",
@@ -87,7 +90,8 @@
                 "react-dom": "^17.0.2",
                 "react-json-view": "^1.21.3",
                 "tsx": "^4.23.0",
-                "underscore": "^1.13.7"
+                "underscore": "^1.13.7",
+                "vite": "^5.4.0"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -109,6 +113,7 @@
         },
         "node_modules/@ampproject/remapping": {
             "version": "2.3.0",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
@@ -147,19 +152,25 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.26.2",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.29.7",
                 "js-tokens": "^4.0.0",
-                "picocolors": "^1.0.0"
+                "picocolors": "^1.1.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.26.5",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -167,6 +178,7 @@
         },
         "node_modules/@babel/core": {
             "version": "7.24.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
@@ -195,6 +207,7 @@
         },
         "node_modules/@babel/core/node_modules/convert-source-map": {
             "version": "2.0.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@babel/eslint-parser": {
@@ -214,13 +227,16 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.26.5",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.26.5",
-                "@babel/types": "^7.26.5",
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.25",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
             },
             "engines": {
@@ -239,11 +255,14 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.26.5",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.26.5",
-                "@babel/helper-validator-option": "^7.25.9",
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -315,6 +334,16 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@babel/helper-globals": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-member-expression-to-functions": {
             "version": "7.25.9",
             "dev": true,
@@ -328,23 +357,29 @@
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.25.9",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.25.9",
-                "@babel/types": "^7.25.9"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.26.0",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9",
-                "@babel/traverse": "^7.25.9"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -365,7 +400,9 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.26.5",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+            "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -417,21 +454,30 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.25.9",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.25.9",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.25.9",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -451,11 +497,14 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.26.0",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.25.9",
-                "@babel/types": "^7.26.0"
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -463,6 +512,7 @@
         },
         "node_modules/@babel/highlight": {
             "version": "7.25.9",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.25.9",
@@ -476,6 +526,7 @@
         },
         "node_modules/@babel/highlight/node_modules/ansi-styles": {
             "version": "3.2.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^1.9.0"
@@ -486,6 +537,7 @@
         },
         "node_modules/@babel/highlight/node_modules/chalk": {
             "version": "2.4.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^3.2.1",
@@ -498,6 +550,7 @@
         },
         "node_modules/@babel/highlight/node_modules/color-convert": {
             "version": "1.9.3",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "1.1.3"
@@ -505,10 +558,12 @@
         },
         "node_modules/@babel/highlight/node_modules/color-name": {
             "version": "1.1.3",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
             "version": "1.0.5",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.0"
@@ -516,6 +571,7 @@
         },
         "node_modules/@babel/highlight/node_modules/has-flag": {
             "version": "3.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=4"
@@ -523,6 +579,7 @@
         },
         "node_modules/@babel/highlight/node_modules/supports-color": {
             "version": "5.5.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-flag": "^3.0.0"
@@ -532,10 +589,13 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.26.5",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.26.5"
+                "@babel/types": "^7.29.7"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -1402,6 +1462,38 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
+        "node_modules/@babel/plugin-transform-react-jsx-self": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+            "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-react-jsx-source": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+            "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
         "node_modules/@babel/plugin-transform-react-pure-annotations": {
             "version": "7.25.9",
             "dev": true,
@@ -1765,39 +1857,48 @@
             "license": "MIT"
         },
         "node_modules/@babel/template": {
-            "version": "7.25.9",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.25.9",
-                "@babel/parser": "^7.25.9",
-                "@babel/types": "^7.25.9"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.26.5",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+            "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.26.2",
-                "@babel/generator": "^7.26.5",
-                "@babel/parser": "^7.26.5",
-                "@babel/template": "^7.25.9",
-                "@babel/types": "^7.26.5",
-                "debug": "^4.3.1",
-                "globals": "^11.1.0"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "debug": "^4.3.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.26.5",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1975,8 +2076,8 @@
             "version": "11.13.5",
             "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
             "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.16.7",
                 "@babel/runtime": "^7.18.3",
@@ -1993,6 +2094,7 @@
         },
         "node_modules/@emotion/cache": {
             "version": "11.14.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@emotion/memoize": "^0.9.0",
@@ -2004,28 +2106,30 @@
         },
         "node_modules/@emotion/hash": {
             "version": "0.9.2",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@emotion/is-prop-valid": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
             "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@emotion/memoize": "^0.9.0"
             }
         },
         "node_modules/@emotion/memoize": {
             "version": "0.9.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@emotion/react": {
             "version": "11.14.0",
             "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
             "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.18.3",
                 "@emotion/babel-plugin": "^11.13.5",
@@ -2049,8 +2153,8 @@
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
             "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@emotion/hash": "^0.9.2",
                 "@emotion/memoize": "^0.9.0",
@@ -2061,14 +2165,15 @@
         },
         "node_modules/@emotion/sheet": {
             "version": "1.4.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@emotion/styled": {
             "version": "11.14.1",
             "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
             "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.18.3",
                 "@emotion/babel-plugin": "^11.13.5",
@@ -2091,25 +2196,27 @@
             "version": "0.10.0",
             "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
             "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
-            "license": "MIT",
-            "peer": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
             "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "react": ">=16.8.0"
             }
         },
         "node_modules/@emotion/utils": {
             "version": "1.4.2",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@emotion/weak-memoize": {
             "version": "0.4.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@es-joy/jsdoccomment": {
@@ -2605,6 +2712,7 @@
         },
         "node_modules/@eslint/eslintrc": {
             "version": "0.4.3",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ajv": "^6.12.4",
@@ -2623,6 +2731,7 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/ajv": {
             "version": "6.12.6",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -2637,6 +2746,7 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/argparse": {
             "version": "1.0.10",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "sprintf-js": "~1.0.2"
@@ -2644,6 +2754,7 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/globals": {
             "version": "13.24.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -2657,6 +2768,7 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/ignore": {
             "version": "4.0.6",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -2664,6 +2776,7 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
             "version": "3.14.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -2675,14 +2788,17 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
             "version": "0.4.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@eslint/eslintrc/node_modules/sprintf-js": {
             "version": "1.0.3",
+            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/@eslint/eslintrc/node_modules/type-fest": {
             "version": "0.20.2",
+            "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=10"
@@ -2726,6 +2842,7 @@
         },
         "node_modules/@floating-ui/core": {
             "version": "1.6.9",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/utils": "^0.2.9"
@@ -2733,6 +2850,7 @@
         },
         "node_modules/@floating-ui/dom": {
             "version": "1.6.13",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/core": "^1.6.0",
@@ -2741,6 +2859,7 @@
         },
         "node_modules/@floating-ui/react-dom": {
             "version": "2.1.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.0.0"
@@ -2752,10 +2871,12 @@
         },
         "node_modules/@floating-ui/utils": {
             "version": "0.2.9",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.5.0",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@humanwhocodes/object-schema": "^1.2.0",
@@ -2768,6 +2889,7 @@
         },
         "node_modules/@humanwhocodes/object-schema": {
             "version": "1.2.1",
+            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/@istanbuljs/load-nyc-config": {
@@ -2875,26 +2997,30 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.8",
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jridgewell/set-array": "^1.2.1",
-                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@jridgewell/set-array": {
-            "version": "1.2.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
@@ -2902,10 +3028,14 @@
         },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.25",
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -3053,6 +3183,7 @@
         },
         "node_modules/@mui/base": {
             "version": "5.0.0-beta.40-0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
@@ -3083,6 +3214,7 @@
         },
         "node_modules/@mui/core-downloads-tracker": {
             "version": "5.16.14",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
@@ -3091,6 +3223,7 @@
         },
         "node_modules/@mui/icons-material": {
             "version": "5.16.14",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.23.9"
@@ -3155,6 +3288,7 @@
         },
         "node_modules/@mui/material": {
             "version": "5.16.14",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
@@ -3198,6 +3332,7 @@
         },
         "node_modules/@mui/private-theming": {
             "version": "5.16.14",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
@@ -3223,6 +3358,7 @@
         },
         "node_modules/@mui/styled-engine": {
             "version": "5.16.14",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
@@ -3293,6 +3429,7 @@
         },
         "node_modules/@mui/system": {
             "version": "5.16.14",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
@@ -3478,22 +3615,9 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/@pkgr/core": {
-            "version": "0.3.6",
-            "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
-            "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": "^14.18.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/pkgr"
-            }
-        },
         "node_modules/@popperjs/core": {
             "version": "2.11.8",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
@@ -3570,6 +3694,363 @@
                 "@rjsf/utils": "^5.24.x"
             }
         },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-beta.27",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+            "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+            "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+            "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+            "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+            "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+            "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+            "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+            "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+            "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+            "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+            "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+            "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+            "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+            "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+            "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+            "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+            "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+            "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+            "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+            "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+            "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+            "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+            "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+            "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+            "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+            "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
         "node_modules/@rtsao/scc": {
             "version": "1.1.0",
             "dev": true,
@@ -3606,6 +4087,51 @@
                 "react": "^17.0.1"
             }
         },
+        "node_modules/@types/babel__core": {
+            "version": "7.20.5",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+            "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.20.7",
+                "@babel/types": "^7.20.7",
+                "@types/babel__generator": "*",
+                "@types/babel__template": "*",
+                "@types/babel__traverse": "*"
+            }
+        },
+        "node_modules/@types/babel__generator": {
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+            "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "node_modules/@types/babel__template": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+            "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "node_modules/@types/babel__traverse": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+            "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.28.2"
+            }
+        },
         "node_modules/@types/chai": {
             "version": "4.3.20",
             "dev": true,
@@ -3618,6 +4144,13 @@
             "dependencies": {
                 "classnames": "*"
             }
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/glob": {
             "version": "7.2.0",
@@ -3714,8 +4247,8 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
             "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-            "license": "MIT",
-            "peer": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/prettier": {
             "version": "2.7.3",
@@ -4069,6 +4602,65 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/@vitejs/plugin-react": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+            "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.28.0",
+                "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+                "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+                "@rolldown/pluginutils": "1.0.0-beta.27",
+                "@types/babel__core": "^7.20.5",
+                "react-refresh": "^0.17.0"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+            }
+        },
+        "node_modules/@vitejs/plugin-react/node_modules/@babel/core": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "@jridgewell/remapping": "^2.3.5",
+                "convert-source-map": "^2.0.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.2.3",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/babel"
+            }
+        },
+        "node_modules/@vitejs/plugin-react/node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/a-sync-waterfall": {
             "version": "1.0.1",
             "dev": true,
@@ -4076,6 +4668,7 @@
         },
         "node_modules/acorn": {
             "version": "7.4.1",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -4086,6 +4679,7 @@
         },
         "node_modules/acorn-jsx": {
             "version": "5.3.2",
+            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -4134,6 +4728,7 @@
         },
         "node_modules/ansi-colors": {
             "version": "4.1.3",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -4155,6 +4750,7 @@
         },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -4162,6 +4758,7 @@
         },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
@@ -4388,6 +4985,7 @@
         },
         "node_modules/astral-regex": {
             "version": "2.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -4427,8 +5025,8 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
             "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.12.5",
                 "cosmiconfig": "^7.0.0",
@@ -4477,6 +5075,7 @@
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/base16": {
@@ -4497,6 +5096,7 @@
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -4521,6 +5121,7 @@
         },
         "node_modules/browserslist": {
             "version": "4.24.4",
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -4633,6 +5234,7 @@
         },
         "node_modules/callsites": {
             "version": "3.1.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -4648,6 +5250,7 @@
         },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001692",
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -4683,6 +5286,7 @@
         },
         "node_modules/chalk": {
             "version": "4.1.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.1.0",
@@ -4870,6 +5474,7 @@
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
@@ -4880,6 +5485,7 @@
         },
         "node_modules/color-name": {
             "version": "1.1.4",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/colorette": {
@@ -4935,6 +5541,7 @@
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/confusing-browser-globals": {
@@ -4944,6 +5551,7 @@
         },
         "node_modules/convert-source-map": {
             "version": "1.9.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/core-js": {
@@ -4982,8 +5590,8 @@
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
             "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/parse-json": "^4.0.0",
                 "import-fresh": "^3.2.1",
@@ -5009,6 +5617,7 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -5124,6 +5733,7 @@
         },
         "node_modules/debug": {
             "version": "4.4.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -5163,6 +5773,7 @@
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/default-require-extensions": {
@@ -5219,17 +5830,6 @@
                 "node": ">=0.3.1"
             }
         },
-        "node_modules/diff-sequences": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
-            "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-            }
-        },
         "node_modules/dir-glob": {
             "version": "3.0.1",
             "dev": true,
@@ -5243,6 +5843,7 @@
         },
         "node_modules/doctrine": {
             "version": "3.0.0",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "esutils": "^2.0.2"
@@ -5283,6 +5884,7 @@
         },
         "node_modules/electron-to-chromium": {
             "version": "1.5.83",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
@@ -5292,6 +5894,7 @@
         },
         "node_modules/enquirer": {
             "version": "2.4.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-colors": "^4.1.1",
@@ -5305,8 +5908,8 @@
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
             "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "is-arrayish": "^0.2.1"
             }
@@ -5563,6 +6166,7 @@
         },
         "node_modules/escalade": {
             "version": "3.2.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -5575,6 +6179,7 @@
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -5585,6 +6190,7 @@
         },
         "node_modules/eslint": {
             "version": "7.32.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "7.12.11",
@@ -5636,37 +6242,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/eslint-compat-utils": {
-            "version": "0.6.5",
-            "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.6.5.tgz",
-            "integrity": "sha512-vAUHYzue4YAa2hNACjB8HvUQj5yehAZgiClyFVVom9cP8z5NSFq3PwB/TtJslN2zAMgRX6FCFCjYBbQh71g5RQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "semver": "^7.5.4"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "peerDependencies": {
-                "eslint": ">=6.0.0"
-            }
-        },
-        "node_modules/eslint-compat-utils/node_modules/semver": {
-            "version": "7.8.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-            "dev": true,
-            "license": "ISC",
-            "peer": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/eslint-config-airbnb": {
@@ -5758,29 +6333,6 @@
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.1"
-            }
-        },
-        "node_modules/eslint-json-compat-utils": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/eslint-json-compat-utils/-/eslint-json-compat-utils-0.2.3.tgz",
-            "integrity": "sha512-RbBmDFyu7FqnjE8F0ZxPNzx5UaptdeS9Uu50r7A+D7s/+FCX+ybiyViYEgFUaFIFqSWJgZRTpL5d8Kanxxl2lQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "esquery": "^1.6.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "peerDependencies": {
-                "eslint": "*",
-                "jsonc-eslint-parser": "^2.4.0 || ^3.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@eslint/json": {
-                    "optional": true
-                }
             }
         },
         "node_modules/eslint-module-utils": {
@@ -5890,81 +6442,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/eslint-plugin-jsonc": {
-            "version": "2.21.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.21.1.tgz",
-            "integrity": "sha512-dbNR5iEnQeORwsK2WZzr3QaMtFCY3kKJVMRHPzUpKzMhmVy2zIpVgFDpX8MNoIdoqz6KCpCfOJavhfiSbZbN+w==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@eslint-community/eslint-utils": "^4.5.1",
-                "diff-sequences": "^27.5.1",
-                "eslint-compat-utils": "^0.6.4",
-                "eslint-json-compat-utils": "^0.2.1",
-                "espree": "^9.6.1 || ^10.3.0",
-                "graphemer": "^1.4.0",
-                "jsonc-eslint-parser": "^2.4.0",
-                "natural-compare": "^1.4.0",
-                "synckit": "^0.6.2 || ^0.7.3 || ^0.11.5"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ota-meshi"
-            },
-            "peerDependencies": {
-                "eslint": ">=6.0.0"
-            }
-        },
-        "node_modules/eslint-plugin-jsonc/node_modules/acorn": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/eslint-plugin-jsonc/node_modules/eslint-visitor-keys": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "peer": true,
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/eslint-plugin-jsonc/node_modules/espree": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "peer": true,
-            "dependencies": {
-                "acorn": "^8.15.0",
-                "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^4.2.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
         "node_modules/eslint-plugin-jsx-a11y": {
             "version": "6.10.2",
             "dev": true,
@@ -6058,20 +6535,6 @@
                 "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
             }
         },
-        "node_modules/eslint-plugin-react-hooks": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
-            "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
-            }
-        },
         "node_modules/eslint-plugin-react/node_modules/doctrine": {
             "version": "2.1.0",
             "dev": true,
@@ -6127,6 +6590,7 @@
         },
         "node_modules/eslint-utils": {
             "version": "2.1.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "eslint-visitor-keys": "^1.1.0"
@@ -6140,6 +6604,7 @@
         },
         "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
             "version": "1.3.0",
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=4"
@@ -6154,6 +6619,7 @@
         },
         "node_modules/eslint/node_modules/@babel/code-frame": {
             "version": "7.12.11",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/highlight": "^7.10.4"
@@ -6161,6 +6627,7 @@
         },
         "node_modules/eslint/node_modules/ajv": {
             "version": "6.12.6",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -6175,6 +6642,7 @@
         },
         "node_modules/eslint/node_modules/argparse": {
             "version": "1.0.10",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "sprintf-js": "~1.0.2"
@@ -6182,6 +6650,7 @@
         },
         "node_modules/eslint/node_modules/globals": {
             "version": "13.24.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -6195,6 +6664,7 @@
         },
         "node_modules/eslint/node_modules/ignore": {
             "version": "4.0.6",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -6202,6 +6672,7 @@
         },
         "node_modules/eslint/node_modules/js-yaml": {
             "version": "3.14.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -6213,10 +6684,12 @@
         },
         "node_modules/eslint/node_modules/json-schema-traverse": {
             "version": "0.4.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/semver": {
             "version": "7.6.3",
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -6227,10 +6700,12 @@
         },
         "node_modules/eslint/node_modules/sprintf-js": {
             "version": "1.0.3",
+            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/eslint/node_modules/type-fest": {
             "version": "0.20.2",
+            "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=10"
@@ -6255,6 +6730,7 @@
         },
         "node_modules/espree": {
             "version": "7.3.1",
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "acorn": "^7.4.0",
@@ -6267,6 +6743,7 @@
         },
         "node_modules/espree/node_modules/eslint-visitor-keys": {
             "version": "1.3.0",
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=4"
@@ -6274,6 +6751,7 @@
         },
         "node_modules/esprima": {
             "version": "4.0.1",
+            "dev": true,
             "license": "BSD-2-Clause",
             "bin": {
                 "esparse": "bin/esparse.js",
@@ -6285,6 +6763,7 @@
         },
         "node_modules/esquery": {
             "version": "1.6.0",
+            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "estraverse": "^5.1.0"
@@ -6312,6 +6791,7 @@
         },
         "node_modules/esutils": {
             "version": "2.0.3",
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -6382,10 +6862,12 @@
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-uri": {
@@ -6439,6 +6921,7 @@
         },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "flat-cache": "^3.0.4"
@@ -6475,8 +6958,8 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
             "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-            "license": "MIT",
-            "peer": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/find-up": {
             "version": "5.0.0",
@@ -6503,6 +6986,7 @@
         },
         "node_modules/flat-cache": {
             "version": "3.2.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "flatted": "^3.2.9",
@@ -6515,6 +6999,7 @@
         },
         "node_modules/flatted": {
             "version": "3.3.2",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/flux": {
@@ -6583,6 +7068,7 @@
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/fscreen": {
@@ -6603,6 +7089,7 @@
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -6629,6 +7116,7 @@
         },
         "node_modules/functional-red-black-tree": {
             "version": "1.0.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/functions-have-names": {
@@ -6641,6 +7129,7 @@
         },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -6745,6 +7234,7 @@
         },
         "node_modules/glob": {
             "version": "7.2.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -6763,6 +7253,7 @@
         },
         "node_modules/glob-parent": {
             "version": "5.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.1"
@@ -6791,6 +7282,7 @@
         },
         "node_modules/globals": {
             "version": "11.12.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=4"
@@ -6887,6 +7379,7 @@
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -6967,6 +7460,7 @@
         },
         "node_modules/hasown": {
             "version": "2.0.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -7040,6 +7534,7 @@
         },
         "node_modules/import-fresh": {
             "version": "3.3.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "parent-module": "^1.0.0",
@@ -7054,6 +7549,7 @@
         },
         "node_modules/imurmurhash": {
             "version": "0.1.4",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.19"
@@ -7069,6 +7565,7 @@
         },
         "node_modules/inflight": {
             "version": "1.0.6",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "once": "^1.3.0",
@@ -7112,8 +7609,8 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-            "license": "MIT",
-            "peer": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/is-async-function": {
             "version": "2.1.0",
@@ -7190,6 +7687,7 @@
         },
         "node_modules/is-core-module": {
             "version": "2.16.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "hasown": "^2.0.2"
@@ -7234,6 +7732,7 @@
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -7283,6 +7782,7 @@
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
@@ -7563,6 +8063,7 @@
         },
         "node_modules/isexe": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/isobject": {
@@ -7750,6 +8251,7 @@
         },
         "node_modules/jsesc": {
             "version": "3.1.0",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "jsesc": "bin/jsesc"
@@ -7760,14 +8262,15 @@
         },
         "node_modules/json-buffer": {
             "version": "3.0.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-            "license": "MIT",
-            "peer": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/json-schema": {
             "version": "0.4.0",
@@ -7844,97 +8347,18 @@
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/json5": {
             "version": "2.2.3",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "json5": "lib/cli.js"
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/jsonc-eslint-parser": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.2.tgz",
-            "integrity": "sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "acorn": "^8.5.0",
-                "eslint-visitor-keys": "^3.0.0",
-                "espree": "^9.0.0",
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ota-meshi"
-            }
-        },
-        "node_modules/jsonc-eslint-parser/node_modules/acorn": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/jsonc-eslint-parser/node_modules/eslint-visitor-keys": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "peer": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/jsonc-eslint-parser/node_modules/espree": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "peer": true,
-            "dependencies": {
-                "acorn": "^8.9.0",
-                "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.4.1"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/jsonc-eslint-parser/node_modules/semver": {
-            "version": "7.8.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-            "dev": true,
-            "license": "ISC",
-            "peer": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/jsonpointer": {
@@ -8077,6 +8501,7 @@
         },
         "node_modules/keyv": {
             "version": "4.5.4",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "json-buffer": "3.0.1"
@@ -8108,6 +8533,7 @@
         },
         "node_modules/levn": {
             "version": "0.4.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "prelude-ls": "^1.2.1",
@@ -8136,8 +8562,8 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-            "license": "MIT",
-            "peer": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lint-staged": {
             "version": "12.5.0",
@@ -8312,10 +8738,12 @@
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.truncate": {
             "version": "4.4.2",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/log-symbols": {
@@ -8425,6 +8853,7 @@
         },
         "node_modules/lru-cache": {
             "version": "5.1.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^3.0.2"
@@ -8574,6 +9003,7 @@
         },
         "node_modules/minimatch": {
             "version": "3.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -8771,7 +9201,7 @@
         },
         "node_modules/moment": {
             "version": "2.30.1",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "*"
@@ -8779,6 +9209,7 @@
         },
         "node_modules/ms": {
             "version": "2.1.3",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/mz": {
@@ -8791,8 +9222,28 @@
                 "thenify-all": "^1.0.0"
             }
         },
+        "node_modules/nanoid": {
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
         "node_modules/natural-compare": {
             "version": "1.4.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/natural-compare-lite": {
@@ -8837,6 +9288,7 @@
         },
         "node_modules/node-releases": {
             "version": "2.0.19",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/normalize-path": {
@@ -9259,6 +9711,7 @@
         },
         "node_modules/once": {
             "version": "1.4.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
@@ -9280,6 +9733,7 @@
         },
         "node_modules/optionator": {
             "version": "0.9.4",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "deep-is": "^0.1.3",
@@ -9383,6 +9837,7 @@
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "callsites": "^3.0.0"
@@ -9395,8 +9850,8 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
             "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.0.0",
                 "error-ex": "^1.3.1",
@@ -9420,6 +9875,7 @@
         },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -9427,6 +9883,7 @@
         },
         "node_modules/path-key": {
             "version": "3.1.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -9434,10 +9891,12 @@
         },
         "node_modules/path-parse": {
             "version": "1.0.7",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/path-type": {
             "version": "4.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -9453,6 +9912,7 @@
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/picomatch": {
@@ -9568,8 +10028,38 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/postcss": {
+            "version": "8.5.19",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+            "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.12",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8.0"
@@ -9624,6 +10114,7 @@
         },
         "node_modules/progress": {
             "version": "2.0.3",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
@@ -9719,6 +10210,7 @@
         },
         "node_modules/punycode": {
             "version": "2.3.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -9762,6 +10254,7 @@
         },
         "node_modules/react": {
             "version": "17.0.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0",
@@ -9801,6 +10294,7 @@
         },
         "node_modules/react-dom": {
             "version": "17.0.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0",
@@ -9941,6 +10435,16 @@
             "version": "17.0.2",
             "license": "MIT"
         },
+        "node_modules/react-refresh": {
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+            "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/react-textarea-autosize": {
             "version": "8.5.7",
             "dev": true,
@@ -10073,6 +10577,7 @@
         },
         "node_modules/regexpp": {
             "version": "3.2.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -10173,6 +10678,7 @@
         },
         "node_modules/resolve": {
             "version": "1.22.10",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-core-module": "^2.16.0",
@@ -10191,6 +10697,7 @@
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=4"
@@ -10232,6 +10739,7 @@
         },
         "node_modules/rimraf": {
             "version": "3.0.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "glob": "^7.1.3"
@@ -10241,6 +10749,51 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/rollup": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+            "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "1.0.9"
+            },
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.62.2",
+                "@rollup/rollup-android-arm64": "4.62.2",
+                "@rollup/rollup-darwin-arm64": "4.62.2",
+                "@rollup/rollup-darwin-x64": "4.62.2",
+                "@rollup/rollup-freebsd-arm64": "4.62.2",
+                "@rollup/rollup-freebsd-x64": "4.62.2",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+                "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+                "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+                "@rollup/rollup-linux-arm64-musl": "4.62.2",
+                "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+                "@rollup/rollup-linux-loong64-musl": "4.62.2",
+                "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+                "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+                "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+                "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+                "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+                "@rollup/rollup-linux-x64-gnu": "4.62.2",
+                "@rollup/rollup-linux-x64-musl": "4.62.2",
+                "@rollup/rollup-openbsd-x64": "4.62.2",
+                "@rollup/rollup-openharmony-arm64": "4.62.2",
+                "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+                "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+                "@rollup/rollup-win32-x64-gnu": "4.62.2",
+                "@rollup/rollup-win32-x64-msvc": "4.62.2",
+                "fsevents": "~2.3.2"
             }
         },
         "node_modules/rope-sequence": {
@@ -10342,6 +10895,7 @@
         },
         "node_modules/scheduler": {
             "version": "0.20.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0",
@@ -10433,6 +10987,7 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
@@ -10443,6 +10998,7 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -10570,6 +11126,17 @@
         },
         "node_modules/source-map": {
             "version": "0.5.7",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -10804,6 +11371,7 @@
         },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -10830,6 +11398,7 @@
         },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -10844,10 +11413,12 @@
         },
         "node_modules/stylis": {
             "version": "4.2.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
@@ -10858,6 +11429,7 @@
         },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -10866,25 +11438,9 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/synckit": {
-            "version": "0.11.13",
-            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
-            "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@pkgr/core": "^0.3.6"
-            },
-            "engines": {
-                "node": "^14.18.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/synckit"
-            }
-        },
         "node_modules/table": {
             "version": "6.9.0",
+            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "ajv": "^8.0.1",
@@ -10899,10 +11455,12 @@
         },
         "node_modules/table/node_modules/emoji-regex": {
             "version": "8.0.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/table/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -10910,6 +11468,7 @@
         },
         "node_modules/table/node_modules/slice-ansi": {
             "version": "4.0.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
@@ -10925,6 +11484,7 @@
         },
         "node_modules/table/node_modules/string-width": {
             "version": "4.2.3",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
@@ -10950,6 +11510,7 @@
         },
         "node_modules/text-table": {
             "version": "0.2.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/thenify": {
@@ -11114,6 +11675,7 @@
         },
         "node_modules/type-check": {
             "version": "0.4.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "prelude-ls": "^1.2.1"
@@ -11359,6 +11921,7 @@
         },
         "node_modules/update-browserslist-db": {
             "version": "1.1.2",
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -11387,6 +11950,7 @@
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
@@ -11455,6 +12019,7 @@
         },
         "node_modules/v8-compile-cache": {
             "version": "2.4.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/valid-url": {
@@ -11484,6 +12049,496 @@
         "node_modules/validate.io-number": {
             "version": "1.0.3"
         },
+        "node_modules/vite": {
+            "version": "5.4.21",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+            "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "^0.21.3",
+                "postcss": "^8.4.43",
+                "rollup": "^4.20.0"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "less": "*",
+                "lightningcss": "^1.21.0",
+                "sass": "*",
+                "sass-embedded": "*",
+                "stylus": "*",
+                "sugarss": "*",
+                "terser": "^5.4.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/android-arm": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+            "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/android-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+            "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/android-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+            "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+            "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+            "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+            "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+            "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-arm": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+            "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+            "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+            "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+            "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+            "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+            "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+            "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/linux-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+            "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+            "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+            "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+            "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/@esbuild/win32-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+            "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite/node_modules/esbuild": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+            "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.21.5",
+                "@esbuild/android-arm": "0.21.5",
+                "@esbuild/android-arm64": "0.21.5",
+                "@esbuild/android-x64": "0.21.5",
+                "@esbuild/darwin-arm64": "0.21.5",
+                "@esbuild/darwin-x64": "0.21.5",
+                "@esbuild/freebsd-arm64": "0.21.5",
+                "@esbuild/freebsd-x64": "0.21.5",
+                "@esbuild/linux-arm": "0.21.5",
+                "@esbuild/linux-arm64": "0.21.5",
+                "@esbuild/linux-ia32": "0.21.5",
+                "@esbuild/linux-loong64": "0.21.5",
+                "@esbuild/linux-mips64el": "0.21.5",
+                "@esbuild/linux-ppc64": "0.21.5",
+                "@esbuild/linux-riscv64": "0.21.5",
+                "@esbuild/linux-s390x": "0.21.5",
+                "@esbuild/linux-x64": "0.21.5",
+                "@esbuild/netbsd-x64": "0.21.5",
+                "@esbuild/openbsd-x64": "0.21.5",
+                "@esbuild/sunos-x64": "0.21.5",
+                "@esbuild/win32-arm64": "0.21.5",
+                "@esbuild/win32-ia32": "0.21.5",
+                "@esbuild/win32-x64": "0.21.5"
+            }
+        },
         "node_modules/w3c-keyname": {
             "version": "2.2.8",
             "license": "MIT"
@@ -11504,6 +12559,7 @@
         },
         "node_modules/which": {
             "version": "2.0.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
@@ -11607,6 +12663,7 @@
         },
         "node_modules/word-wrap": {
             "version": "1.2.5",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -11661,6 +12718,7 @@
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/write-file-atomic": {
@@ -11684,10 +12742,12 @@
         },
         "node_modules/yallist": {
             "version": "3.1.1",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/yaml": {
             "version": "1.10.2",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">= 6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@exabyte-io/cove.js",
+    "name": "@mat3ra/cove.js",
     "version": "0.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "@exabyte-io/cove.js",
+            "name": "@mat3ra/cove.js",
             "version": "0.0.0",
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
         "transpile": "tsc",
         "prettier": "prettier --check src",
         "prepare": "husky install",
-        "test": "npm run lint && npm run transpile"
+        "test": "npm run lint && npm run transpile",
+        "dev:standalone": "vite",
+        "build:standalone": "vite build"
     },
     "repository": {
         "type": "git",
@@ -79,6 +81,8 @@
         "underscore.string": "^3.3.6"
     },
     "devDependencies": {
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.1",
         "@exabyte-io/eslint-config": "2025.5.13-0",
         "@mat3ra/code": "2024.10.4-0",
         "@mat3ra/esse": "2024.12.19-1",
@@ -93,6 +97,7 @@
         "@types/underscore": "^1.13.0",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
+        "@vitejs/plugin-react": "^4.3.0",
         "chai": "^4.5.0",
         "classnames": "^2.5.1",
         "eslint": "^7.32.0",
@@ -119,7 +124,8 @@
         "react-dom": "^17.0.2",
         "react-json-view": "^1.21.3",
         "tsx": "^4.23.0",
-        "underscore": "^1.13.7"
+        "underscore": "^1.13.7",
+        "vite": "^5.4.0"
     },
     "engines": {
         "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@exabyte-io/cove.js",
+    "name": "@mat3ra/cove.js",
     "version": "0.0.0",
     "description": "Cove.js - reusable components",
     "scripts": {
@@ -12,7 +12,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/Exabyte-io/cove.js.git"
+        "url": "https://github.com/mat3ra/cove.js.git"
     },
     "main": "dist/index.js",
     "files": [
@@ -22,10 +22,10 @@
     ],
     "author": "Exabyte Inc.",
     "bugs": {
-        "url": "https://github.com/Exabyte-io/cove.js/issues"
+        "url": "https://github.com/mat3ra/cove.js/issues"
     },
     "license": "Apache-2.0",
-    "homepage": "https://github.com/Exabyte-io/cove.js",
+    "homepage": "https://github.com/mat3ra/cove.js",
     "peerDependencies": {
         "@mat3ra/code": "*",
         "@mat3ra/esse": "*",

--- a/src/standalone/GalleryApp.tsx
+++ b/src/standalone/GalleryApp.tsx
@@ -1,0 +1,145 @@
+import AppBar from "@mui/material/AppBar";
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import CssBaseline from "@mui/material/CssBaseline";
+import Drawer from "@mui/material/Drawer";
+import Link from "@mui/material/Link";
+import List from "@mui/material/List";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemText from "@mui/material/ListItemText";
+import ListSubheader from "@mui/material/ListSubheader";
+import MenuItem from "@mui/material/MenuItem";
+import Paper from "@mui/material/Paper";
+import { ThemeProvider } from "@mui/material/styles";
+import TextField from "@mui/material/TextField";
+import Toolbar from "@mui/material/Toolbar";
+import Typography from "@mui/material/Typography";
+import React, { useEffect, useMemo, useState } from "react";
+
+import { DarkMaterialUITheme, LightMaterialUITheme, oldLightMaterialUITheme } from "../theme/theme";
+import type { GalleryEntry } from "./manifest";
+import { GALLERY } from "./manifest";
+
+const DRAWER_WIDTH = 280;
+
+const THEMES = {
+    "Light (default)": oldLightMaterialUITheme,
+    "Light (MD)": LightMaterialUITheme,
+    "Dark (MD)": DarkMaterialUITheme,
+} as const;
+
+type ThemeName = keyof typeof THEMES;
+
+function entryFromHash(): GalleryEntry {
+    const name = decodeURIComponent(window.location.hash.replace(/^#/, ""));
+    return GALLERY.find((e) => e.name === name) || GALLERY[0];
+}
+
+export default function GalleryApp() {
+    const [selected, setSelected] = useState<GalleryEntry>(entryFromHash);
+    const [themeName, setThemeName] = useState<ThemeName>("Light (default)");
+    const [filter, setFilter] = useState("");
+
+    useEffect(() => {
+        const onHashChange = () => setSelected(entryFromHash());
+        window.addEventListener("hashchange", onHashChange);
+        return () => window.removeEventListener("hashchange", onHashChange);
+    }, []);
+
+    const grouped = useMemo(() => {
+        const visible = GALLERY.filter((e) => e.name.toLowerCase().includes(filter.toLowerCase()));
+        const byCategory = new Map<string, GalleryEntry[]>();
+        visible.forEach((entry) => {
+            const list = byCategory.get(entry.category) || [];
+            list.push(entry);
+            byCategory.set(entry.category, list);
+        });
+        return byCategory;
+    }, [filter]);
+
+    return (
+        <ThemeProvider theme={THEMES[themeName]}>
+            <CssBaseline />
+            <Box sx={{ display: "flex" }}>
+                <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
+                    <Toolbar sx={{ gap: 2 }}>
+                        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+                            cove.js — Component Gallery
+                        </Typography>
+                        <TextField
+                            select
+                            size="small"
+                            value={themeName}
+                            onChange={(event) => setThemeName(event.target.value as ThemeName)}
+                            sx={{ minWidth: 170, bgcolor: "background.paper", borderRadius: 1 }}>
+                            {Object.keys(THEMES).map((name) => (
+                                <MenuItem key={name} value={name}>
+                                    {name}
+                                </MenuItem>
+                            ))}
+                        </TextField>
+                        <Link
+                            href="https://github.com/mat3ra/cove.js"
+                            color="inherit"
+                            underline="hover"
+                            target="_blank"
+                            rel="noreferrer">
+                            GitHub
+                        </Link>
+                    </Toolbar>
+                </AppBar>
+                <Drawer
+                    variant="permanent"
+                    sx={{
+                        width: DRAWER_WIDTH,
+                        flexShrink: 0,
+                        "& .MuiDrawer-paper": { width: DRAWER_WIDTH, boxSizing: "border-box" },
+                    }}>
+                    <Toolbar />
+                    <Box sx={{ p: 1.5 }}>
+                        <TextField
+                            fullWidth
+                            size="small"
+                            placeholder="Filter components…"
+                            value={filter}
+                            onChange={(event) => setFilter(event.target.value)}
+                        />
+                    </Box>
+                    <Box sx={{ overflow: "auto" }}>
+                        {Array.from(grouped.entries()).map(([category, entries]) => (
+                            <List
+                                key={category}
+                                dense
+                                subheader={<ListSubheader>{category}</ListSubheader>}>
+                                {entries.map((entry) => (
+                                    <ListItemButton
+                                        key={entry.name}
+                                        selected={entry.name === selected.name}
+                                        onClick={() => {
+                                            window.location.hash = encodeURIComponent(entry.name);
+                                        }}>
+                                        <ListItemText primary={entry.name} />
+                                    </ListItemButton>
+                                ))}
+                            </List>
+                        ))}
+                    </Box>
+                </Drawer>
+                <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+                    <Toolbar />
+                    <Box sx={{ mb: 2, display: "flex", alignItems: "center", gap: 1.5 }}>
+                        <Typography variant="h5">{selected.name}</Typography>
+                        <Chip size="small" label={selected.category} />
+                    </Box>
+                    <Typography variant="caption" color="text.secondary" gutterBottom>
+                        {selected.source}
+                    </Typography>
+                    <Paper variant="outlined" sx={{ mt: 1.5, p: 3 }}>
+                        {/* key remounts demo state on selection change */}
+                        <Box key={selected.name}>{selected.render()}</Box>
+                    </Paper>
+                </Box>
+            </Box>
+        </ThemeProvider>
+    );
+}

--- a/src/standalone/index.tsx
+++ b/src/standalone/index.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import ReactDOM from "react-dom";
+
+import GalleryApp from "./GalleryApp";
+
+const container = document.getElementById("root");
+if (!container) {
+    throw new Error("Root element not found");
+}
+// react-dom 17 — no createRoot here.
+ReactDOM.render(<GalleryApp />, container);

--- a/src/standalone/manifest.tsx
+++ b/src/standalone/manifest.tsx
@@ -1,0 +1,389 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import React, { useState } from "react";
+
+import Accordion from "../mui/components/accordion/Accordion";
+import ButtonMultiSelect from "../mui/components/button/ButtonMultiSelect";
+import CheckboxComponent from "../mui/components/checkbox/Checkbox";
+import InfoWidget from "../mui/components/custom/widgets/info-widget/InfoWidget";
+import TotalWidget from "../mui/components/custom/widgets/total-widget/TotalWidget";
+import Dialog from "../mui/components/dialog/Dialog";
+import IconByName from "../mui/components/icon/IconByName";
+import LinearProgress from "../mui/components/linear-progress/LinearProgress";
+import InfoPopover from "../mui/components/popover/info-popover/InfoPopover";
+import RadioGroup from "../mui/components/radio-group/RadioGroup";
+import BasicSelect from "../mui/components/select/BasicSelect";
+import StyledStepper from "../mui/components/stepper/Stepper";
+import TabsMenu from "../mui/components/tabs/TabsMenu";
+import { AccountCard } from "../mui-composed/components/account/AccountCard";
+import { LoadingIndicator } from "../mui-composed/components/loading/LoadingIndicator";
+import JSONViewer from "../other/object-viewer/json-viewer/JSONViewer";
+import PlainTextViewer from "../other/object-viewer/plain-text-viewer/PlainTextViewer";
+import { ButtonTest } from "../theme/themeTest/buttons/Button";
+import { ButtonGroupTest } from "../theme/themeTest/buttons/ButtonGroup";
+import { IconButtonTest } from "../theme/themeTest/buttons/IconButton";
+import { SwitchTest } from "../theme/themeTest/buttons/Switch";
+import { ToggleButtonTest } from "../theme/themeTest/buttons/ToggleButton";
+import { AutocompleteTest } from "../theme/themeTest/inputs/Autocomplete";
+import { SelectTest } from "../theme/themeTest/inputs/Select";
+import { TextFieldTest } from "../theme/themeTest/inputs/TextField";
+import { TypographyTest } from "../theme/themeTest/typography/Typography";
+
+export type GalleryEntry = {
+    category: string;
+    name: string;
+    /** Repo path shown under the demo so readers can jump to the source. */
+    source: string;
+    render: () => React.ReactElement;
+};
+
+const noop = () => undefined;
+
+const ICON_NAMES = [
+    "entities.workflow",
+    "entities.unit",
+    "entities.subworkflow",
+    "entities.material",
+    "shapes.save",
+    "shapes.arrow.down",
+];
+
+function CheckboxDemo() {
+    const [checked, setChecked] = useState(true);
+    return (
+        <CheckboxComponent
+            id="gallery-checkbox"
+            label="Enable feature"
+            value="feature"
+            checked={checked}
+            required={false}
+            disabled={false}
+            className=""
+            onChange={(isChecked: boolean) => setChecked(isChecked)}
+        />
+    );
+}
+
+function RadioGroupDemo() {
+    const [value, setValue] = useState<string | number>("medium");
+    return (
+        <RadioGroup
+            id="gallery-radio-group"
+            label="Precision"
+            value={value}
+            items={[
+                { label: "Low", value: "low" },
+                { label: "Medium", value: "medium" },
+                { label: "High", value: "high" },
+            ]}
+            onChange={(_event, newValue) => setValue(newValue)}
+        />
+    );
+}
+
+function BasicSelectDemo() {
+    const [value, setValue] = useState("espresso");
+    return (
+        <BasicSelect
+            id="gallery-basic-select"
+            label="Application"
+            selectedValue={value}
+            options={[
+                { id: "espresso", name: "espresso" },
+                { id: "vasp", name: "vasp" },
+                { id: "nwchem", name: "nwchem" },
+            ]}
+            onChange={setValue}
+        />
+    );
+}
+
+function StepperDemo() {
+    const [activeStep, setActiveStep] = useState(1);
+    const steps = ["Material", "Workflow", "Compute", "Submit"];
+    return (
+        <Stack spacing={2}>
+            <StyledStepper activeStep={activeStep} steps={steps} fullWidth />
+            <Stack direction="row" spacing={1}>
+                <Button
+                    size="small"
+                    disabled={activeStep === 0}
+                    onClick={() => setActiveStep((s) => s - 1)}>
+                    Back
+                </Button>
+                <Button
+                    size="small"
+                    disabled={activeStep === steps.length - 1}
+                    onClick={() => setActiveStep((s) => s + 1)}>
+                    Next
+                </Button>
+            </Stack>
+        </Stack>
+    );
+}
+
+function TabsMenuDemo() {
+    const [activeTabIndex, setActiveTabIndex] = useState(0);
+    return (
+        <Stack spacing={2}>
+            <TabsMenu
+                tabs={[
+                    {
+                        itemName: "Overview",
+                        className: "gallery-tab",
+                        onClick: () => setActiveTabIndex(0),
+                    },
+                    {
+                        itemName: "Results",
+                        className: "gallery-tab",
+                        onClick: () => setActiveTabIndex(1),
+                    },
+                    {
+                        itemName: "Files",
+                        className: "gallery-tab",
+                        onClick: () => setActiveTabIndex(2),
+                    },
+                ]}
+                activeTabIndex={activeTabIndex}
+            />
+            <Typography variant="body2">Active tab index: {activeTabIndex}</Typography>
+        </Stack>
+    );
+}
+
+function DialogDemo() {
+    const [open, setOpen] = useState(false);
+    return (
+        <>
+            <Button variant="contained" onClick={() => setOpen(true)}>
+                Open dialog
+            </Button>
+            <Dialog
+                id="gallery-dialog"
+                open={open}
+                titleComponent="Example Dialog"
+                onClose={() => setOpen(false)}
+                onSubmit={() => setOpen(false)}>
+                <Typography sx={{ p: 2 }}>
+                    Dialog content goes here. Submit and close are wired to buttons below.
+                </Typography>
+            </Dialog>
+        </>
+    );
+}
+
+export const GALLERY: GalleryEntry[] = [
+    // ---- mui: inputs & controls -------------------------------------------------
+    {
+        category: "Inputs & Controls",
+        name: "ButtonMultiSelect",
+        source: "src/mui/components/button/ButtonMultiSelect.tsx",
+        render: () => (
+            <ButtonMultiSelect
+                id="gallery-button-multi-select"
+                localStorageKey="gallery-button-multi-select"
+                buttonConfigs={[
+                    { id: "save", iconName: "shapes.save", label: "Save", onClick: noop },
+                    {
+                        id: "save-as",
+                        iconName: "shapes.save",
+                        label: "Save As…",
+                        onClick: noop,
+                    },
+                ]}
+            />
+        ),
+    },
+    {
+        category: "Inputs & Controls",
+        name: "Checkbox",
+        source: "src/mui/components/checkbox/Checkbox.tsx",
+        render: () => <CheckboxDemo />,
+    },
+    {
+        category: "Inputs & Controls",
+        name: "RadioGroup",
+        source: "src/mui/components/radio-group/RadioGroup.tsx",
+        render: () => <RadioGroupDemo />,
+    },
+    {
+        category: "Inputs & Controls",
+        name: "BasicSelect",
+        source: "src/mui/components/select/BasicSelect.tsx",
+        render: () => <BasicSelectDemo />,
+    },
+    // ---- mui: layout & navigation -----------------------------------------------
+    {
+        category: "Layout & Navigation",
+        name: "Accordion",
+        source: "src/mui/components/accordion/Accordion.tsx",
+        render: () => (
+            <Accordion header="Important Settings" isExpanded>
+                <Typography variant="body2">Accordion body content.</Typography>
+            </Accordion>
+        ),
+    },
+    {
+        category: "Layout & Navigation",
+        name: "TabsMenu",
+        source: "src/mui/components/tabs/TabsMenu.tsx",
+        render: () => <TabsMenuDemo />,
+    },
+    {
+        category: "Layout & Navigation",
+        name: "Stepper",
+        source: "src/mui/components/stepper/Stepper.tsx",
+        render: () => <StepperDemo />,
+    },
+    {
+        category: "Layout & Navigation",
+        name: "Dialog",
+        source: "src/mui/components/dialog/Dialog.tsx",
+        render: () => <DialogDemo />,
+    },
+    // ---- mui: display -------------------------------------------------------------
+    {
+        category: "Display",
+        name: "LinearProgress",
+        source: "src/mui/components/linear-progress/LinearProgress.tsx",
+        render: () => (
+            <Stack spacing={2}>
+                <LinearProgress percent={25} />
+                <LinearProgress percent={60} />
+                <LinearProgress percent={90} />
+            </Stack>
+        ),
+    },
+    {
+        category: "Display",
+        name: "InfoPopover",
+        source: "src/mui/components/popover/info-popover/InfoPopover.tsx",
+        render: () => (
+            <InfoPopover id="gallery-info-popover" title="What is this?">
+                <Typography variant="body2" sx={{ p: 1 }}>
+                    Contextual help content shown on hover/click.
+                </Typography>
+            </InfoPopover>
+        ),
+    },
+    {
+        category: "Display",
+        name: "InfoWidget",
+        source: "src/mui/components/custom/widgets/info-widget/InfoWidget.tsx",
+        render: () => (
+            <InfoWidget
+                title="Cluster status"
+                description="All queues operational"
+                content={<Typography variant="h4">98.6%</Typography>}
+            />
+        ),
+    },
+    {
+        category: "Display",
+        name: "TotalWidget",
+        source: "src/mui/components/custom/widgets/total-widget/TotalWidget.tsx",
+        render: () => (
+            <TotalWidget
+                id="gallery-total-widget"
+                sum={128}
+                label="Jobs this month"
+                iconName="entities.workflow"
+                boxColor="#3d5afe22"
+            />
+        ),
+    },
+    {
+        category: "Display",
+        name: "IconByName",
+        source: "src/mui/components/icon/IconByName.tsx",
+        render: () => (
+            <Stack direction="row" spacing={3}>
+                {ICON_NAMES.map((name) => (
+                    <Box key={name} textAlign="center">
+                        <IconByName name={name} fontSize="large" />
+                        <Typography variant="caption" display="block">
+                            {name}
+                        </Typography>
+                    </Box>
+                ))}
+            </Stack>
+        ),
+    },
+    // ---- mui-composed ------------------------------------------------------------
+    {
+        category: "Composed",
+        name: "AccountCard",
+        source: "src/mui-composed/components/account/AccountCard.tsx",
+        render: () => (
+            <Stack spacing={2}>
+                <AccountCard account={{ name: "Dream Team" }} subtitle="organization" />
+                <AccountCard
+                    account={{ name: "Jane Researcher" }}
+                    subtitle="personal"
+                    size="large"
+                />
+            </Stack>
+        ),
+    },
+    {
+        category: "Composed",
+        name: "LoadingIndicator",
+        source: "src/mui-composed/components/loading/LoadingIndicator.tsx",
+        render: () => <LoadingIndicator included maxHeight={120} />,
+    },
+    // ---- other ---------------------------------------------------------------------
+    {
+        category: "Viewers",
+        name: "JSONViewer",
+        source: "src/other/object-viewer/json-viewer/JSONViewer.tsx",
+        render: () => (
+            <JSONViewer
+                src={{ name: "Silicon FCC", formula: "Si", lattice: { type: "FCC", a: 3.867 } }}
+                onUpdate={noop}
+            />
+        ),
+    },
+    {
+        category: "Viewers",
+        name: "PlainTextViewer",
+        source: "src/other/object-viewer/plain-text-viewer/PlainTextViewer.tsx",
+        render: () => (
+            <PlainTextViewer src={"Si2\n1.0\n0.0 2.734 2.734\n2.734 0.0 2.734\n2.734 2.734 0.0"} />
+        ),
+    },
+    // ---- theme test harness --------------------------------------------------------
+    {
+        category: "Theme",
+        name: "Buttons",
+        source: "src/theme/themeTest/buttons/",
+        render: () => (
+            <Stack spacing={2}>
+                <ButtonTest />
+                <IconButtonTest />
+                <ButtonGroupTest />
+                <ToggleButtonTest />
+                <SwitchTest />
+            </Stack>
+        ),
+    },
+    {
+        category: "Theme",
+        name: "Inputs",
+        source: "src/theme/themeTest/inputs/",
+        render: () => (
+            <Stack spacing={2}>
+                <TextFieldTest />
+                <AutocompleteTest />
+                <SelectTest />
+            </Stack>
+        ),
+    },
+    {
+        category: "Theme",
+        name: "Typography",
+        source: "src/theme/themeTest/typography/Typography.tsx",
+        render: () => <TypographyTest />,
+    },
+];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
   ],
   "exclude": [
     "node_modules",
-    "dist"
+    "dist",
+    "./src/standalone"
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,18 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+/**
+ * Vite config for the standalone component gallery (`npm run dev:standalone`),
+ * deployed to GitHub Pages by the `deploy-bundle` CI job. The library build
+ * (`npm run transpile`) is unaffected — it uses tsc/tsconfig.json, which
+ * excludes `src/standalone`.
+ */
+export default defineConfig({
+    // Matches the repo name so assets resolve under the GitHub Pages
+    // subpath (mat3ra.github.io/cove.js/). Harmless for local dev.
+    base: "/cove.js/",
+    plugins: [react()],
+    build: {
+        outDir: "build",
+    },
+});


### PR DESCRIPTION
Adds a standalone component gallery (in the spirit of mui-theme-creator's component browser) and deploys it to GitHub Pages at https://mat3ra.github.io/cove.js/.

- `src/standalone/` vite app: grouped sidebar with filtering, hash routing (`#ComponentName`), live interactive demos (stateful Checkbox/Stepper/Tabs/Dialog etc.), and a theme switcher across `oldLightMaterialUITheme` / `LightMaterialUITheme` / `DarkMaterialUITheme`.
- Manifest-driven (`src/standalone/manifest.tsx`) — adding a component is one `{category, name, source, render}` entry.
- New `deploy-bundle` CI job publishes `build/` to the `gh-pages` branch on merges to `main` (same pattern as the workflow-designer repo).
- `src/standalone` is excluded from `tsconfig.json`, so the published `dist/` is unchanged; vite/@vitejs/plugin-react/@emotion added as devDependencies only.

Verified locally: `npm run build:standalone` builds clean and the app renders with zero console errors in light and dark themes.

Stacked on #91 (scope migration) — merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)