### PR TITLE
fix: correct GitHub Pages base path in vite.config.ts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,8 +9,8 @@ import { defineConfig } from "vite";
  */
 export default defineConfig({
     // Matches the repo name so assets resolve under the GitHub Pages
-    // subpath (mat3ra.github.io/cove.js/). Harmless for local dev.
-    base: "/cove.js/",
+    // subpath (mat3ra.github.io/cove/). Harmless for local dev.
+    base: "/cove/",
     plugins: [react()],
     build: {
         outDir: "build",


### PR DESCRIPTION
## Summary
- The component gallery deployed to GitHub Pages (mat3ra.github.io/cove/) rendered blank because `vite.config.ts` still set `base: "/cove.js/"`, a leftover from before the repo was renamed/migrated to `@mat3ra` scope. The bundle's script tag pointed at `/cove.js/assets/...` and 404'd under the actual `/cove/` Pages subpath.
- Updated `base` to `/cove/` to match the current repo name and Pages URL.

## Test plan
- [x] Ran `npm run build:standalone` and confirmed `build/index.html` now references `/cove/assets/...`
- [x] Served the build locally under a `/cove/` subpath and confirmed the gallery renders (sidebar, component list, component previews) with no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)