### PR TITLE
chore: rename package to @mat3ra/cove

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,22 @@ cove houses entity definitions for use in the Mat3ra platform.
 For usage within a javascript project:
 
 ```bash
-npm install @mat3ra/cove.js
+npm install @mat3ra/cove
 ```
 
 For development:
 
 ```bash
-git clone https://github.com/mat3ra/cove.js.git
-cd cove.js
+git clone https://github.com/mat3ra/cove.git
+cd cove
 npm install
 npm run transpile
 ```
 
-How to link cove.js to host app:
+How to link cove to host app:
 ```bash
-rm -rf {PATH}/exabyte-stack/web-app/src/application/node_modules/@mat3ra/cove.js/dist
-ln -s "$(pwd)/dist/" /{ABSOLUTE_PATH}/exabyte-stack/web-app/src/application/node_modules/@mat3ra/cove.js
+rm -rf {PATH}/exabyte-stack/web-app/src/application/node_modules/@mat3ra/cove/dist
+ln -s "$(pwd)/dist/" /{ABSOLUTE_PATH}/exabyte-stack/web-app/src/application/node_modules/@mat3ra/cove
 restart host app (web-app, wave etc.)
 ```
 
@@ -34,10 +34,10 @@ another approach is to access cove from repo
 
 ```bash
 push your branch
-replace cove.js version with url in package.json
-"@mat3ra/cove.js": "https://github.com/mat3ra/cove.js#cc48da9652840eb0f7d8854e02cb690484e6fab1",
+replace cove version with url in package.json
+"@mat3ra/cove": "https://github.com/mat3ra/cove#cc48da9652840eb0f7d8854e02cb690484e6fab1",
 ```
-make sure to install appropriate versions of peerDependencies from cove.js to host app
+make sure to install appropriate versions of peerDependencies from cove to host app
 
 DO NOT use `npm link` as it leads to having multiple react libs in app.
 See links:
@@ -49,7 +49,7 @@ https://legacy.reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-rea
 Typescript and all necessary type dependencies must be present in dependency section of package.json in order
 to transpile files and generate type definitions during package installation on postinstall command.
 It is necessary for testing arbitrary branches for example as dependency
-git+https://github.com/mat3ra/cove.js.git#b7604da7717232ac38a6372fea603f0b04645ade in web-app.
+git+https://github.com/mat3ra/cove.git#b7604da7717232ac38a6372fea603f0b04645ade in web-app.
 
 ### Contribution
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>cove.js — Component Gallery</title>
+        <title>cove — Component Gallery</title>
     </head>
     <body>
         <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@mat3ra/cove.js",
+    "name": "@mat3ra/cove",
     "version": "0.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "@mat3ra/cove.js",
+            "name": "@mat3ra/cove",
             "version": "0.0.0",
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@mat3ra/cove.js",
+    "name": "@mat3ra/cove",
     "version": "0.0.0",
     "description": "Cove.js - reusable components",
     "scripts": {
@@ -14,7 +14,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/mat3ra/cove.js.git"
+        "url": "https://github.com/mat3ra/cove.git"
     },
     "main": "dist/index.js",
     "files": [
@@ -24,10 +24,10 @@
     ],
     "author": "Exabyte Inc.",
     "bugs": {
-        "url": "https://github.com/mat3ra/cove.js/issues"
+        "url": "https://github.com/mat3ra/cove/issues"
     },
     "license": "Apache-2.0",
-    "homepage": "https://github.com/mat3ra/cove.js",
+    "homepage": "https://github.com/mat3ra/cove",
     "peerDependencies": {
         "@mat3ra/code": "*",
         "@mat3ra/esse": "*",

--- a/src/standalone/GalleryApp.tsx
+++ b/src/standalone/GalleryApp.tsx
@@ -64,7 +64,7 @@ export default function GalleryApp() {
                 <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
                     <Toolbar sx={{ gap: 2 }}>
                         <Typography variant="h6" sx={{ flexGrow: 1 }}>
-                            cove.js — Component Gallery
+                            cove — Component Gallery
                         </Typography>
                         <TextField
                             select
@@ -79,7 +79,7 @@ export default function GalleryApp() {
                             ))}
                         </TextField>
                         <Link
-                            href="https://github.com/mat3ra/cove.js"
+                            href="https://github.com/mat3ra/cove"
                             color="inherit"
                             underline="hover"
                             target="_blank"


### PR DESCRIPTION
Matches the repo rename (`mat3ra/cove.js` → `mat3ra/cove`): package name, repository/bugs/homepage URLs, README, and the gallery's page title/GitHub link. `dist/` has no self-references, so this is a metadata-only change; lockfile name field updated.

npm can't rename a package in place, so this publishes fresh as `@mat3ra/cove` (starting its own version history); `@mat3ra/cove.js` will be deprecated pointing here once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)